### PR TITLE
infra: USB ethernet auto-setup on pedrogpt boot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Secrets - never commit
+secrets/
+
+# Build output
+pedro-ops
+
+# Go
+*.test
+*.out
+vendor/

--- a/scripts/pedrogpt/setup-ethernet.sh
+++ b/scripts/pedrogpt/setup-ethernet.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# setup-ethernet.sh
+# Installs and enables the USB ethernet systemd service on pedrogpt (root@pedrogpt).
+# Run this script once after first boot or after OS reinstall.
+#
+# Usage: sudo bash setup-ethernet.sh
+#
+# The interface enx9c69d319a411 is the USB ethernet adapter providing LAN
+# connectivity. This script makes it persistent across reboots without
+# relying on NetworkManager.
+
+set -euo pipefail
+
+INTERFACE="enx9c69d319a411"
+SERVICE_NAME="usb-ethernet.service"
+SERVICE_SRC="$(dirname "$0")/${SERVICE_NAME}"
+SERVICE_DST="/etc/systemd/system/${SERVICE_NAME}"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Error: this script must be run as root." >&2
+  exit 1
+fi
+
+# Verify the interface exists
+if ! ip link show "${INTERFACE}" &>/dev/null; then
+  echo "Warning: interface ${INTERFACE} not found. Make sure the USB ethernet adapter is connected."
+fi
+
+# Install dhcpcd if missing
+if ! command -v dhcpcd &>/dev/null; then
+  echo "dhcpcd not found — installing..."
+  apt-get install -y dhcpcd5
+fi
+
+# Copy unit file
+echo "Installing ${SERVICE_NAME} to ${SERVICE_DST}..."
+cp "${SERVICE_SRC}" "${SERVICE_DST}"
+chmod 644 "${SERVICE_DST}"
+
+# Reload and enable
+systemctl daemon-reload
+systemctl enable "${SERVICE_NAME}"
+systemctl start "${SERVICE_NAME}"
+
+echo "Done. ${SERVICE_NAME} is enabled and started."
+echo "Verify with: systemctl status ${SERVICE_NAME}"

--- a/scripts/pedrogpt/usb-ethernet.service
+++ b/scripts/pedrogpt/usb-ethernet.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=USB Ethernet Setup
+Documentation=https://github.com/Soypete/pedro-ops
+After=network-pre.target
+Before=network.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/sbin/ip link set enx9c69d319a411 up
+ExecStart=/usr/sbin/dhcpcd enx9c69d319a411
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #4

## Summary

- Adds `scripts/pedrogpt/usb-ethernet.service` — a systemd `oneshot` unit that brings up the USB ethernet adapter (`enx9c69d319a411`) and runs `dhcpcd` on every boot
- Adds `scripts/pedrogpt/setup-ethernet.sh` — a one-time install script to copy and enable the service via SSH (`root@pedrogpt`)
- Adds `.gitignore` to prevent `secrets/` from ever being committed

## Test plan

- [ ] SSH to `root@pedrogpt` and run `setup-ethernet.sh`
- [ ] Verify `systemctl status usb-ethernet.service` shows `active (exited)`
- [ ] Reboot the machine; confirm interface gets a DHCP address without manual intervention
- [ ] Confirm `ping -c 4 8.8.8.8` succeeds after reboot
- [ ] Confirm Tailscale address `pedrogpt` is reachable after reboot
- [ ] Confirm no secrets are present in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)