### PR TITLE
Add llama.cpp model presets and deploy script

### DIFF
--- a/scripts/pedrogpt/README.md
+++ b/scripts/pedrogpt/README.md
@@ -1,0 +1,226 @@
+# pedrogpt Operations Guide
+
+Runtime operations for the llama-server on pedrogpt (100.121.229.114, RTX 5090).
+
+The server runs in **router mode**: all 5 models are registered, one loads at a time.
+Callers switch models by setting `"model"` in the API request — no service restarts needed.
+
+---
+
+## Endpoints
+
+Base URL: `http://100.121.229.114:8080`
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Server health — returns `{"status":"ok"}` when ready |
+| `/v1/models` | GET | List all registered models |
+| `/v1/chat/completions` | POST | OpenAI-compatible chat completions |
+| `/metrics` | GET | Prometheus metrics |
+
+### Check health
+
+```bash
+curl http://100.121.229.114:8080/health
+```
+
+### List registered models
+
+```bash
+curl http://100.121.229.114:8080/v1/models | jq '.data[].id'
+```
+
+Expected output:
+```
+"gpt-oss-20b"
+"nemotron-3-super-120b"
+"qwen3-next-80b"
+"qwen3-coder-30b"
+"qwen2.5-vl-32b"
+```
+
+---
+
+## Switching Models via API
+
+Set `"model"` to any registered model name. The server unloads the current model and
+loads the requested one (~30s swap time on first request).
+
+```bash
+# General chat / reasoning (default, loads on startup)
+curl http://100.121.229.114:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-oss-20b",
+    "messages": [{"role": "user", "content": "explain recursion"}],
+    "max_tokens": 500
+  }'
+
+# Heavy reasoning
+curl http://100.121.229.114:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "nemotron-3-super-120b", "messages": [{"role": "user", "content": "solve this step by step..."}], "max_tokens": 1000}'
+
+# Coding (large context, MoE expert offload)
+curl http://100.121.229.114:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "qwen3-next-80b", "messages": [{"role": "user", "content": "write a Go HTTP server"}], "max_tokens": 500}'
+
+# Coding (lighter, faster)
+curl http://100.121.229.114:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "qwen3-coder-30b", "messages": [{"role": "user", "content": "write a Go HTTP server"}], "max_tokens": 500}'
+
+# Vision (pass image as base64 or URL)
+curl http://100.121.229.114:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen2.5-vl-32b",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "what is in this image?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+      ]
+    }],
+    "max_tokens": 300
+  }'
+```
+
+> **Note:** gpt-oss-20b and nemotron are reasoning models. They produce `reasoning_content`
+> internally before outputting `content`. Use `max_tokens >= 500` to get a complete response.
+
+---
+
+## Debugging
+
+### Check service status
+
+```bash
+ssh soypete@100.121.229.114
+sudo systemctl status llama-server
+```
+
+### Tail live logs
+
+```bash
+ssh soypete@100.121.229.114 "sudo journalctl -u llama-server -f"
+```
+
+### Common errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `activating (auto-restart)` | Service crash loop | Check `journalctl -u llama-server -n 50` |
+| `model not found` | Wrong model name in API request | Use exact section names from INI (e.g. `gpt-oss-20b`) |
+| `--flash-attn: expected value` | Old flag syntax | Use `--flash-attn on` in drop-in |
+| Empty `content`, has `reasoning_content` | Reasoning model hit token limit | Increase `max_tokens` |
+| CUDA forward compat warning | Non-fatal driver mismatch warning | Ignore — model still loads on CPU or GPU |
+| Model swap hangs >60s | Previous model didn't unload | Restart service: `sudo systemctl restart llama-server` |
+
+### Inspect the active systemd config
+
+```bash
+ssh soypete@100.121.229.114 "systemctl cat llama-server"
+```
+
+### Check which model is loaded
+
+```bash
+curl http://100.121.229.114:8080/v1/models | jq '.data[] | select(.meta.n_ctx_train) | {id, loaded: true}'
+```
+
+---
+
+## Adding a New Model
+
+1. **Find the model** — check [LiveBench](https://livebench.ai) for scores, find GGUF on HuggingFace
+   (prefer `unsloth` or `bartowski` repos, `UD-Q4_K_XL` for MoE, `Q4_K_M` for dense)
+
+2. **Download to pedrogpt:**
+
+```bash
+ssh soypete@100.121.229.114
+~/.local/bin/hf download <org>/<model>-GGUF \
+  --include "*Q4_K_M*" \
+  --local-dir ~/models/<model-name>
+sudo mv ~/models/<model-name> /opt/models/
+```
+
+3. **Add a section to `presets/all-models.ini`:**
+
+```ini
+[my-new-model]
+model = /opt/models/my-new-model/my-new-model-Q4_K_M.gguf
+ctx-size = 16384
+```
+
+4. **Deploy the updated INI:**
+
+```bash
+scp scripts/pedrogpt/presets/*.ini soypete@100.121.229.114:/tmp/
+ssh soypete@100.121.229.114 "sudo mv /tmp/*.ini /opt/llama.cpp/presets/ && sudo chmod 644 /opt/llama.cpp/presets/*.ini"
+```
+
+5. **Restart the service:**
+
+```bash
+ssh soypete@100.121.229.114 "sudo systemctl restart llama-server"
+```
+
+6. **Verify it's registered:**
+
+```bash
+curl http://100.121.229.114:8080/v1/models | jq '.data[].id'
+```
+
+---
+
+## Maintenance
+
+### Restart the service
+
+```bash
+ssh soypete@100.121.229.114 "sudo systemctl restart llama-server"
+```
+
+### View the drop-in override
+
+```bash
+cat /etc/systemd/system/llama-server.service.d/preset.conf
+```
+
+### Rollback to single-model mode
+
+```bash
+ssh soypete@100.121.229.114
+sudo rm /etc/systemd/system/llama-server.service.d/preset.conf
+sudo systemctl daemon-reload
+sudo systemctl restart llama-server
+```
+
+### Check Prometheus metrics
+
+```bash
+curl http://100.121.229.114:8080/metrics | grep -E 'llama_|requests_'
+```
+
+### GPU memory usage
+
+```bash
+ssh soypete@100.121.229.114 "nvidia-smi --query-gpu=memory.used,memory.free,memory.total --format=csv"
+```
+
+---
+
+## Files
+
+| Path | Description |
+|------|-------------|
+| `/opt/llama.cpp/` | llama.cpp build |
+| `/opt/llama.cpp/presets/all-models.ini` | Active model roster |
+| `/opt/models/` | Downloaded GGUF model files |
+| `/etc/systemd/system/llama-server.service` | Base systemd unit |
+| `/etc/systemd/system/llama-server.service.d/preset.conf` | Drop-in override (router mode) |
+| `/etc/llama-server.env` | Runtime env vars (PORT, N_PARALLEL) |
+| `scripts/pedrogpt/presets/` | Source INI files (deploy from here) |

--- a/scripts/pedrogpt/deploy-presets.sh
+++ b/scripts/pedrogpt/deploy-presets.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+
+# Deploy llama.cpp model presets to pedrogpt and restart the service.
+#
+# Copies preset INI files to pedrogpt via SCP (over Tailscale) and optionally
+# restarts llama-server with the specified preset.
+#
+# Prerequisites:
+#   - SSH access to pedrogpt via Tailscale (ssh pedrogpt)
+#   - llama-server systemd service installed (setup-llama-cpp.sh)
+#
+# Usage:
+#   ./deploy-presets.sh                    # Deploy all presets, no restart
+#   ./deploy-presets.sh --preset text      # Deploy + activate text preset
+#   ./deploy-presets.sh --preset code      # Deploy + activate code preset
+#   ./deploy-presets.sh --preset vision    # Deploy + activate vision preset
+#   ./deploy-presets.sh --preset all       # Deploy + activate router (all models)
+#   ./deploy-presets.sh --taildrop         # Use Taildrop instead of SCP
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PRESETS_DIR="$SCRIPT_DIR/presets"
+REMOTE_HOST="pedrogpt"
+REMOTE_PRESETS_DIR="/opt/llama.cpp/presets"
+REMOTE_ENV_FILE="/etc/llama-server.env"
+SERVICE_NAME="llama-server"
+
+PRESET=""
+USE_TAILDROP=false
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --preset)
+      PRESET="$2"
+      shift 2
+      ;;
+    --taildrop)
+      USE_TAILDROP=true
+      shift
+      ;;
+    --host)
+      REMOTE_HOST="$2"
+      shift 2
+      ;;
+    -h|--help)
+      head -17 "$0" | tail -14
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate preset name
+if [[ -n "$PRESET" ]]; then
+  case "$PRESET" in
+    text|code|vision|tts|all) ;;
+    *)
+      echo "ERROR: Unknown preset '$PRESET'"
+      echo "Valid presets: text, code, vision, tts, all"
+      exit 1
+      ;;
+  esac
+fi
+
+# Map preset name to INI file
+preset_file() {
+  case "$1" in
+    text)   echo "text.ini" ;;
+    code)   echo "code.ini" ;;
+    vision) echo "vision.ini" ;;
+    tts)    echo "tts.ini" ;;
+    all)    echo "all-models.ini" ;;
+  esac
+}
+
+echo "=== Deploying llama.cpp presets to $REMOTE_HOST ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Copy preset files
+# ---------------------------------------------------------------------------
+if [[ "$USE_TAILDROP" == "true" ]]; then
+  echo "--- Sending presets via Taildrop ---"
+  for f in "$PRESETS_DIR"/*.ini; do
+    echo "  Sending $(basename "$f")"
+    tailscale file cp "$f" "$REMOTE_HOST:"
+  done
+  echo ""
+  echo "Files sent via Taildrop. On pedrogpt, accept and move them:"
+  echo "  sudo mkdir -p $REMOTE_PRESETS_DIR"
+  echo "  sudo mv ~/Taildrop/*.ini $REMOTE_PRESETS_DIR/"
+  echo ""
+
+  if [[ -n "$PRESET" ]]; then
+    echo "Then restart the service with:"
+    echo "  sudo systemctl restart $SERVICE_NAME"
+    echo ""
+    echo "(Cannot auto-restart via Taildrop — use SCP mode for full automation)"
+  fi
+else
+  echo "--- Copying presets via SCP ---"
+  ssh -t "$REMOTE_HOST" "sudo mkdir -p $REMOTE_PRESETS_DIR"
+  scp "$PRESETS_DIR"/*.ini "$REMOTE_HOST:/tmp/"
+  ssh -t "$REMOTE_HOST" "sudo mv /tmp/*.ini $REMOTE_PRESETS_DIR/ && sudo chmod 644 $REMOTE_PRESETS_DIR/*.ini"
+  echo "  Presets deployed to $REMOTE_HOST:$REMOTE_PRESETS_DIR/"
+  echo ""
+
+  # -------------------------------------------------------------------------
+  # Restart service with preset (SCP mode only)
+  # -------------------------------------------------------------------------
+  if [[ -n "$PRESET" ]]; then
+    INI_FILE="$(preset_file "$PRESET")"
+    REMOTE_INI="$REMOTE_PRESETS_DIR/$INI_FILE"
+
+    echo "--- Activating preset: $PRESET ($INI_FILE) ---"
+
+    # Build extra flags for specific presets
+    EXTRA_FLAGS=""
+    if [[ "$PRESET" == "code" || "$PRESET" == "all" ]]; then
+      # MoE expert offload: keep attention on GPU, experts in 64GB RAM
+      EXTRA_FLAGS='    -ot ".ffn_.*_exps.=CPU" \\\n    --flash-attn \\'
+    fi
+
+    PRESET_PORT="\${PORT}"
+    if [[ "$PRESET" == "tts" ]]; then
+      PRESET_PORT="8001"
+    fi
+
+    # Update the systemd override to use --models-preset
+    ssh -t "$REMOTE_HOST" "sudo mkdir -p /etc/systemd/system/${SERVICE_NAME}.service.d"
+    ssh "$REMOTE_HOST" "sudo tee /etc/systemd/system/${SERVICE_NAME}.service.d/preset.conf > /dev/null" <<EOF
+[Service]
+ExecStart=
+ExecStart=/opt/llama.cpp/build/bin/llama-server \\
+    --host 0.0.0.0 \\
+    --port $PRESET_PORT \\
+    --models-preset $REMOTE_INI \\
+    --models-max 1 \\
+    --parallel \${N_PARALLEL} \\
+    --jinja \\
+    --no-webui \\
+    --metrics$(if [[ -n "$EXTRA_FLAGS" ]]; then printf " \\\\\n$EXTRA_FLAGS"; fi)
+EOF
+
+    ssh -t "$REMOTE_HOST" "sudo systemctl daemon-reload && sudo systemctl restart $SERVICE_NAME"
+    sleep 3
+
+    # Check health
+    if ssh -t "$REMOTE_HOST" "sudo systemctl is-active --quiet $SERVICE_NAME"; then
+      echo ""
+      echo "=== Preset '$PRESET' active on $REMOTE_HOST ==="
+      echo "Health:  curl http://$REMOTE_HOST:8080/health"
+      echo "Models:  curl http://$REMOTE_HOST:8080/v1/models"
+      echo "Logs:    ssh $REMOTE_HOST sudo journalctl -u $SERVICE_NAME -f"
+    else
+      echo "ERROR: $SERVICE_NAME failed to start"
+      ssh -t "$REMOTE_HOST" "sudo journalctl -u $SERVICE_NAME -n 30"
+      exit 1
+    fi
+  else
+    echo "Presets deployed. Use --preset <name> to activate one."
+    echo "Available: text, code, vision, tts, all"
+  fi
+fi
+
+echo ""
+echo "=== Done ==="

--- a/scripts/pedrogpt/deploy-presets.sh
+++ b/scripts/pedrogpt/deploy-presets.sh
@@ -125,7 +125,7 @@ else
     EXTRA_FLAGS=""
     if [[ "$PRESET" == "code" || "$PRESET" == "all" ]]; then
       # MoE expert offload: keep attention on GPU, experts in 64GB RAM
-      EXTRA_FLAGS='    -ot ".ffn_.*_exps.=CPU" \\\n    --flash-attn \\'
+      EXTRA_FLAGS='    -ot ".ffn_.*_exps.=CPU" \\\n    --flash-attn on \\'
     fi
 
     PRESET_PORT="\${PORT}"

--- a/scripts/pedrogpt/deploy-presets.sh
+++ b/scripts/pedrogpt/deploy-presets.sh
@@ -133,9 +133,11 @@ else
       PRESET_PORT="8001"
     fi
 
-    # Update the systemd override to use --models-preset
-    ssh -t "$REMOTE_HOST" "sudo mkdir -p /etc/systemd/system/${SERVICE_NAME}.service.d"
-    ssh "$REMOTE_HOST" "sudo tee /etc/systemd/system/${SERVICE_NAME}.service.d/preset.conf > /dev/null" <<EOF
+    # Write preset.conf to a local temp file, SCP it, then move into place with sudo
+    TMPCONF="$(mktemp)"
+    trap 'rm -f "$TMPCONF"' EXIT
+
+    cat > "$TMPCONF" <<CONF
 [Service]
 ExecStart=
 ExecStart=/opt/llama.cpp/build/bin/llama-server \\
@@ -143,11 +145,13 @@ ExecStart=/opt/llama.cpp/build/bin/llama-server \\
     --port $PRESET_PORT \\
     --models-preset $REMOTE_INI \\
     --models-max 1 \\
-    --parallel \${N_PARALLEL} \\
     --jinja \\
     --no-webui \\
     --metrics$(if [[ -n "$EXTRA_FLAGS" ]]; then printf " \\\\\n$EXTRA_FLAGS"; fi)
-EOF
+CONF
+
+    scp "$TMPCONF" "$REMOTE_HOST:/tmp/preset.conf"
+    ssh -t "$REMOTE_HOST" "sudo mkdir -p /etc/systemd/system/${SERVICE_NAME}.service.d && sudo mv /tmp/preset.conf /etc/systemd/system/${SERVICE_NAME}.service.d/preset.conf && sudo chmod 644 /etc/systemd/system/${SERVICE_NAME}.service.d/preset.conf"
 
     ssh -t "$REMOTE_HOST" "sudo systemctl daemon-reload && sudo systemctl restart $SERVICE_NAME"
     sleep 3

--- a/scripts/pedrogpt/llama-cpp-scrapeconfig.yaml
+++ b/scripts/pedrogpt/llama-cpp-scrapeconfig.yaml
@@ -1,10 +1,11 @@
-# ScrapeConfig for llama.cpp running on pedrogpt (external to k8s cluster).
+# ScrapeConfigs for llama.cpp running on pedrogpt (external to k8s cluster).
 #
-# llama-server must be started with the --metrics flag, which enables the
-# Prometheus endpoint at /metrics on the server port (default 8080).
+# In router mode (--models-preset), the /metrics endpoint requires a ?model=
+# query parameter. Each model gets its own ScrapeConfig so Prometheus can
+# track per-model throughput independently.
 #
 # Apply to the monitoring namespace:
-#   kubectl apply -f charts/monitoring/llama-cpp-scrapeconfig.yaml
+#   kubectl apply -f llama-cpp-scrapeconfig.yaml
 #
 # The kube-prometheus-stack is configured with:
 #   serviceMonitorSelectorNilUsesHelmValues: false
@@ -19,7 +20,7 @@
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
-  name: llama-cpp-pedrogpt
+  name: llama-cpp-gpt-oss-20b
   namespace: monitoring
   labels:
     app.kubernetes.io/name: llama-cpp
@@ -32,6 +33,101 @@ spec:
       labels:
         job: llama-cpp
         instance: pedrogpt
+        model: gpt-oss-20b
   metricsPath: /metrics
+  params:
+    model: ["gpt-oss-20b"]
+  scrapeInterval: 30s
+  scrapeTimeout: 15s
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: llama-cpp-nemotron-3-super-120b
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: llama-cpp
+    app.kubernetes.io/instance: pedrogpt
+    app.kubernetes.io/component: llm-server
+spec:
+  staticConfigs:
+    - targets:
+        - "100.121.229.114:8080"
+      labels:
+        job: llama-cpp
+        instance: pedrogpt
+        model: nemotron-3-super-120b
+  metricsPath: /metrics
+  params:
+    model: ["nemotron-3-super-120b"]
+  scrapeInterval: 30s
+  scrapeTimeout: 15s
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: llama-cpp-qwen3-coder-30b
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: llama-cpp
+    app.kubernetes.io/instance: pedrogpt
+    app.kubernetes.io/component: llm-server
+spec:
+  staticConfigs:
+    - targets:
+        - "100.121.229.114:8080"
+      labels:
+        job: llama-cpp
+        instance: pedrogpt
+        model: qwen3-coder-30b
+  metricsPath: /metrics
+  params:
+    model: ["qwen3-coder-30b"]
+  scrapeInterval: 30s
+  scrapeTimeout: 15s
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: llama-cpp-qwen3-next-80b
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: llama-cpp
+    app.kubernetes.io/instance: pedrogpt
+    app.kubernetes.io/component: llm-server
+spec:
+  staticConfigs:
+    - targets:
+        - "100.121.229.114:8080"
+      labels:
+        job: llama-cpp
+        instance: pedrogpt
+        model: qwen3-next-80b
+  metricsPath: /metrics
+  params:
+    model: ["qwen3-next-80b"]
+  scrapeInterval: 30s
+  scrapeTimeout: 15s
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: llama-cpp-qwen2-5-vl-32b
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/name: llama-cpp
+    app.kubernetes.io/instance: pedrogpt
+    app.kubernetes.io/component: llm-server
+spec:
+  staticConfigs:
+    - targets:
+        - "100.121.229.114:8080"
+      labels:
+        job: llama-cpp
+        instance: pedrogpt
+        model: qwen2.5-vl-32b
+  metricsPath: /metrics
+  params:
+    model: ["qwen2.5-vl-32b"]
   scrapeInterval: 30s
   scrapeTimeout: 15s

--- a/scripts/pedrogpt/multi-model-llama-blog-draft.md
+++ b/scripts/pedrogpt/multi-model-llama-blog-draft.md
@@ -1,0 +1,174 @@
+# From One Model to Many: Running a Multi-Model LLM Router on an RTX 5090 with llama.cpp and systemd
+
+We recently upgraded our local AI inference setup on pedrogpt — a machine with an NVIDIA RTX 5090 (32GB VRAM) and 64GB of system RAM — from running a single hardcoded model to a full multi-model router. Five models, one server process, zero restarts to switch between them. Here's how we did it.
+
+---
+
+## The Old Setup
+
+The original `llama-server` service was simple: one model, loaded at startup, served forever.
+
+```ini
+[Service]
+EnvironmentFile=/etc/llama-server.env
+ExecStart=/opt/llama.cpp/build/bin/llama-server \
+    --host 0.0.0.0 \
+    --port 8080 \
+    --hf-repo unsloth/gpt-oss-20b-GGUF \
+    --hf-file gpt-oss-20b-Q4_K_M.gguf \
+    --ctx-size 8192 \
+    --n-gpu-layers -1 \
+    --parallel 4 \
+    --jinja --no-webui --metrics
+```
+
+To switch models you'd update `/etc/llama-server.env`, restart the service, wait for the model to load, and hope nothing was mid-inference. It worked, but it wasn't flexible enough for a multi-purpose assistant — you want a coding model for code, a reasoning model for analysis, a vision model for images.
+
+---
+
+## The New Setup: `--models-preset`
+
+llama.cpp added a `--models-preset` flag that lets you define a roster of models in an INI file. The server registers all of them at startup but only loads one at a time into VRAM. Callers switch models by setting `"model"` in the API request — the same field as the OpenAI API. The server handles the swap automatically (~30 seconds to unload the current model and load the next one).
+
+### The model roster (`all-models.ini`)
+
+```ini
+version = 1
+
+[*]
+n-gpu-layers = -1
+ctx-size = 8192
+jinja = true
+stop-timeout = 30
+
+[gpt-oss-20b]
+model = /opt/models/gpt-oss-20b/gpt-oss-20b-Q4_K_M.gguf
+ctx-size = 16384
+load-on-startup = true
+
+[nemotron-3-super-120b]
+model = /opt/models/nemotron-3-super-120b/UD-Q4_K_XL/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_XL-00001-of-00003.gguf
+ctx-size = 16384
+temp = 0.6
+top-p = 0.95
+
+[qwen3-next-80b]
+model = /opt/models/qwen3-next-80b/Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL.gguf
+n-gpu-layers = 99
+ctx-size = 65536
+flash-attn = true
+
+[qwen3-coder-30b]
+model = /opt/models/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
+ctx-size = 32768
+
+[qwen2.5-vl-32b]
+model = /opt/models/qwen2.5-vl-32b/qwen2.5-vl-32b-instruct-q4_k_m.gguf
+ctx-size = 8192
+```
+
+Each section name (e.g. `gpt-oss-20b`) is the model identifier callers use in API requests. The `[*]` section sets defaults for all models. `load-on-startup = true` on the default model means it's hot in VRAM immediately after the service starts.
+
+### The new systemd drop-in
+
+Rather than touching the base `llama-server.service` file, we use a drop-in override at `/etc/systemd/system/llama-server.service.d/preset.conf`. This keeps the base unit clean and makes rollback trivial.
+
+```ini
+[Service]
+ExecStart=
+ExecStart=/opt/llama.cpp/build/bin/llama-server \
+    --host 0.0.0.0 \
+    --port ${PORT} \
+    --models-preset /opt/llama.cpp/presets/all-models.ini \
+    --models-max 1 \
+    --parallel ${N_PARALLEL} \
+    --jinja \
+    --no-webui \
+    --metrics \
+    -ot ".ffn_.*_exps.=CPU" \
+    --flash-attn on
+```
+
+The first blank `ExecStart=` clears the original command before setting the new one — that's how systemd drop-ins work. `${PORT}` and `${N_PARALLEL}` come from the existing `/etc/llama-server.env`.
+
+---
+
+## MoE Models and Hardware Config: The Interesting Part
+
+Three of our five models are Mixture-of-Experts (MoE) architectures. MoE models have a large total parameter count but only activate a fraction of those parameters per forward pass. This is what makes them practical on consumer hardware.
+
+### How MoE fits our hardware
+
+| Model | Total params | Active params | GGUF size | Strategy |
+|-------|-------------|---------------|-----------|----------|
+| GPT-OSS 20B | 20B (dense) | 20B | 11 GB | All GPU |
+| Nemotron-3-Super 120B-A12B | 120B | 12B | ~79 GB | GPU attn + RAM experts |
+| Qwen3-Next 80B-A3B | 80B | 3B | ~43 GB | GPU attn + RAM experts |
+| Qwen3-Coder 30B-A3B | 30B | 3B | 18 GB | All GPU |
+| Qwen2.5-VL 32B | 32B (dense) | 32B | 19 GB | All GPU |
+
+The RTX 5090 has 32GB of VRAM. The two large MoE models (Nemotron 120B and Qwen3-Next 80B) can't fit their full weight files in VRAM — but they don't need to. In MoE, the FFN expert layers are the large weight matrices that are only partially activated. We can offload those to the 64GB of system RAM and keep everything else on the GPU.
+
+### Tensor offloading with `-ot`
+
+llama.cpp's `-ot` flag lets you route specific tensor patterns to a device. We use:
+
+```
+-ot ".ffn_.*_exps.=CPU"
+```
+
+This regex matches all FFN expert weight tensors (`ffn_gate_exps`, `ffn_down_exps`, `ffn_up_exps`, etc.) and sends them to CPU/RAM. The attention layers, embeddings, and active expert routing stay on the RTX 5090. During inference, the GPU fetches only the expert weights it needs for each token via PCIe — not the entire weight file.
+
+Combined with `--flash-attn on`, which reduces KV cache memory pressure during long-context inference, this lets us run a 120B-parameter model on a single consumer GPU with 32GB VRAM.
+
+### Multi-part GGUFs
+
+Nemotron-3-Super came as a 3-file GGUF set (`*-00001-of-00003.gguf`, etc.) totaling ~79GB. llama.cpp handles multi-part GGUFs natively — you point it at the first file and it reads the rest automatically. The INI just references `*-00001-of-00003.gguf`.
+
+---
+
+## Switching Models
+
+From the caller's perspective, switching models is one field in the JSON body:
+
+```bash
+# Default: general reasoning
+curl http://pedrogpt:8080/v1/chat/completions \
+  -d '{"model": "gpt-oss-20b", "messages": [...]}'
+
+# Code generation
+curl http://pedrogpt:8080/v1/chat/completions \
+  -d '{"model": "qwen3-coder-30b", "messages": [...]}'
+
+# Heavy reasoning with a 120B MoE
+curl http://pedrogpt:8080/v1/chat/completions \
+  -d '{"model": "nemotron-3-super-120b", "messages": [...]}'
+```
+
+The server sees the `model` field, checks if that model is loaded, unloads the current one if not, loads the requested model, and processes the request. The `--models-max 1` flag enforces that only one model occupies VRAM at a time.
+
+---
+
+## Deployment
+
+We manage this with a deploy script that:
+
+1. SCPs the INI files to `/opt/llama.cpp/presets/` on pedrogpt
+2. Writes the systemd drop-in via `sudo tee`
+3. Runs `systemctl daemon-reload && systemctl restart llama-server`
+
+Models are pre-downloaded to `/opt/models/` using `huggingface-cli` with `--local-dir` — no HuggingFace streaming at runtime. This means startup is fast (no download wait) and the service works without internet access.
+
+---
+
+## What Changed for Callers
+
+The API is OpenAI-compatible. The only change clients need is setting the `"model"` field to the section name from the INI (e.g. `gpt-oss-20b` instead of `unsloth/gpt-oss-20b-GGUF`). Everything else — endpoint, request format, response format — stays the same.
+
+---
+
+## Results
+
+Five models, one port, one process. The RTX 5090's 32GB VRAM comfortably holds any of the dense models outright, and with expert offloading to RAM, even a 120B MoE becomes practical. Model swap latency is ~30 seconds — acceptable for task-switching workloads where you're not hot-swapping mid-conversation.
+
+The llama.cpp `--models-preset` feature does the heavy lifting. The systemd drop-in keeps the operational config clean and rollback to single-model mode is one `rm` and a restart.

--- a/scripts/pedrogpt/multi-model-llama-blog-draft.md
+++ b/scripts/pedrogpt/multi-model-llama-blog-draft.md
@@ -172,3 +172,69 @@ The API is OpenAI-compatible. The only change clients need is setting the `"mode
 Five models, one port, one process. The RTX 5090's 32GB VRAM comfortably holds any of the dense models outright, and with expert offloading to RAM, even a 120B MoE becomes practical. Model swap latency is ~30 seconds — acceptable for task-switching workloads where you're not hot-swapping mid-conversation.
 
 The llama.cpp `--models-preset` feature does the heavy lifting. The systemd drop-in keeps the operational config clean and rollback to single-model mode is one `rm` and a restart.
+
+---
+
+## Addendum: Context Windows, Quantization, and What We Learned the Hard Way
+
+After the initial deployment, we iterated on context window sizes and quantization choices. Here's what we found.
+
+### Bumping Context Windows
+
+The original preset used conservative `ctx-size` values (8192–16384). We bumped these to match each model's actual training context length:
+
+| Model | Old ctx-size | New ctx-size | Model max |
+|-------|-------------|-------------|-----------|
+| gpt-oss-20b | 16,384 | 32,768 | 32,768 |
+| nemotron-3-super-120b | 16,384 | 131,072 | 1,048,576 |
+| qwen3-next-80b | 65,536 | 131,072 | 131,072 |
+| qwen3-coder-30b | 32,768 | 131,072 | 131,072 |
+| qwen2.5-vl-32b | 8,192 | 32,768 | 32,768 |
+
+One gotcha: the preset INI files live in the repo but the *running* server uses the copy deployed to `/opt/llama.cpp/presets/`. Updating the repo without redeploying means the server keeps serving the old config. The `/v1/models` endpoint shows the active `ctx-size` per model — always check there, not the repo.
+
+### Per-Model Overrides vs CLI Flags
+
+Our initial setup passed `-ot ".ffn_.*_exps.=CPU" --flash-attn on` on the CLI, which applied globally to every model. This works but is a blunt instrument — dense models like gpt-oss-20b don't need expert offloading, and the global `--parallel` flag forced the same slot count on every model.
+
+The better approach is per-model configuration in the INI:
+
+```ini
+[nemotron-3-super-120b]
+override-tensor = .ffn_.*_exps.=CPU
+flash-attn = true
+no-mmap = true
+parallel = 1
+```
+
+This lets each model define its own offload strategy, parallelism, and memory settings. The CLI-level flags are reserved for things that truly apply to every model (like `--jinja` and `--metrics`).
+
+### The Quantization Trap: Q4_K_XL vs Q3_K_M for MoE
+
+We originally used the `UD-Q4_K_XL` quant for Nemotron-3-Super-120B (~77 GB across 3 GGUF files). With all experts offloaded to CPU, it loaded and ran at ~4.3 tokens/second generation speed — usable but slow.
+
+We tried to speed it up with selective expert offloading: keep layers 0–14 on GPU and offload only layers 15+ to CPU. The idea was to reduce the number of CPU↔GPU round-trips per token. It failed — llama.cpp tried to allocate a single ~79 GB CUDA buffer for the retained expert layers and OOM'd immediately. Even keeping just layers 0–4 on GPU triggered the same allocation. The expert tensors in this model are too large for partial offloading on 32 GB VRAM.
+
+We switched to `Q3_K_M` (~52 GB, single file). The tradeoffs:
+
+- **RAM headroom**: 52 GB in RAM vs 77 GB leaves more room for the OS, KV cache, and other processes
+- **Quality**: Slightly lower fidelity than Q4_K_XL, but for a 120B MoE with only 12B active params, the per-expert quality loss is less impactful than it would be for a dense model
+- **Speed**: Same generation speed (~4–5 tok/s) since the bottleneck is CPU expert inference over PCIe, not quantization level
+- **Single file**: No multi-part GGUF complexity
+
+### Performance Tuning for MoE on CPU+GPU
+
+For MoE models with expert offloading, we found these settings matter:
+
+- **`no-mmap = true`**: llama.cpp itself recommends this when using tensor overrides to CPU. With mmap, the OS page cache competes with the model for RAM. Without mmap, the model loads into a dedicated allocation.
+- **`parallel = 1`**: Each parallel slot reserves its own KV cache in VRAM. For a 131K context window, 4 slots × 131K tokens is a huge KV footprint. Dropping to 1 slot freed significant VRAM. For a model that's already slow at ~4 tok/s, concurrent request handling isn't the bottleneck.
+- **`flash-attn = true`**: Reduces KV cache memory pressure, critical at 131K context lengths.
+
+### The Deploy Script Problem
+
+Our `deploy-presets.sh` script uses SSH to copy files and restart the service remotely. In practice, `ssh -t` with `sudo` prompts is fragile from non-interactive scripts — heredocs conflict with terminal allocation, and password prompts fail silently. The workaround:
+
+1. SCP the preset files to `/tmp/` on the remote (no sudo needed)
+2. SSH in interactively to move files and restart the service
+
+Long-term fix: passwordless sudo for the specific `systemctl` and `cp` commands the deploy script needs, via a sudoers rule on pedrogpt.

--- a/scripts/pedrogpt/presets/README.md
+++ b/scripts/pedrogpt/presets/README.md
@@ -41,8 +41,9 @@ curl http://localhost:8080/v1/chat/completions \
   -d '{"model": "qwen3-coder-30b", "messages": [{"role": "user", "content": "write a go function"}]}'
 ```
 
-With `--models-max 1`, only one model stays in VRAM. The server swaps
-automatically (~30s load time) when you request a different model name.
+With `--models-max 1`, only one model occupies VRAM at a time. When you
+request a different model, the server evicts the current model from VRAM
+and loads the new one (~30s swap time).
 
 ### MoE expert offload (Qwen3-Next 80B)
 

--- a/scripts/pedrogpt/presets/README.md
+++ b/scripts/pedrogpt/presets/README.md
@@ -53,10 +53,12 @@ attention on GPU. Add `-ot` to the CLI (not in the INI):
 llama-server \
   --models-preset /opt/llama.cpp/presets/code.ini \
   -ot ".ffn_.*_exps.=CPU" \
-  --flash-attn \
+  --flash-attn on \
   --host 0.0.0.0 --port 8080 \
   --metrics
 ```
+
+> **Note:** `--flash-attn` requires an explicit value (`on`, `off`, or `auto`). Omitting it causes a startup error.
 
 ### TTS (separate process on port 8001)
 

--- a/scripts/pedrogpt/presets/README.md
+++ b/scripts/pedrogpt/presets/README.md
@@ -1,0 +1,221 @@
+# llama.cpp Model Presets
+
+Model preset configurations for pedrogpt (RTX 5090, 32GB VRAM, 64GB RAM).
+
+Ref: [Model Management in llama.cpp](https://huggingface.co/blog/ggml-org/model-management-in-llamacpp)
+
+## Presets
+
+| Preset | Section Name | Model | Type | Use Case |
+|--------|-------------|-------|------|----------|
+| `text.ini` | `gpt-oss-20b` | GPT-OSS 20B Q4_K_M | Dense | General chat, reasoning (default) |
+| `text.ini` | `nemotron-3-super-120b` | Nemotron-3-Super 120B-A12B UD-Q4_K_XL | MoE (12B active) | Heavy reasoning |
+| `code.ini` | `qwen3-next-80b` | Qwen3-Next 80B-A3B UD-Q4_K_XL | MoE (3B active) | Code gen, expert offload |
+| `code.ini` | `qwen3-coder-30b` | Qwen3-Coder 30B-A3B Q4_K_M | MoE (3B active) | Code gen, fully GPU |
+| `vision.ini` | `qwen2.5-vl-32b` | Qwen2.5-VL 32B Q4_K_M | Dense | Image understanding, OCR |
+| `tts.ini` | `qwen2.5-omni-7b` | Qwen2.5-Omni 7B | Dense | Text-to-speech (port 8001) |
+| `all-models.ini` | all of the above | — | Router | Dynamic switching via API |
+
+## How It Works
+
+With `--models-preset`, llama-server registers all models from the INI file.
+You switch models by setting the `"model"` field in your API request to the
+**section name** from the INI. The server loads/unloads on demand:
+
+```bash
+# Start server with all models registered
+llama-server \
+  --models-preset /opt/llama.cpp/presets/all-models.ini \
+  --models-max 1 \
+  --host 0.0.0.0 --port 8080 \
+  --metrics
+
+# Use the default model (gpt-oss-20b loads on startup)
+curl http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "gpt-oss-20b", "messages": [{"role": "user", "content": "hello"}]}'
+
+# Switch to coding model — server unloads gpt-oss, loads qwen3-coder
+curl http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "qwen3-coder-30b", "messages": [{"role": "user", "content": "write a go function"}]}'
+```
+
+With `--models-max 1`, only one model stays in VRAM. The server swaps
+automatically (~30s load time) when you request a different model name.
+
+### MoE expert offload (Qwen3-Next 80B)
+
+For large MoE models, offload expert layers to system RAM while keeping
+attention on GPU. Add `-ot` to the CLI (not in the INI):
+
+```bash
+llama-server \
+  --models-preset /opt/llama.cpp/presets/code.ini \
+  -ot ".ffn_.*_exps.=CPU" \
+  --flash-attn \
+  --host 0.0.0.0 --port 8080 \
+  --metrics
+```
+
+### TTS (separate process on port 8001)
+
+```bash
+llama-server \
+  --models-preset /opt/llama.cpp/presets/tts.ini \
+  --host 0.0.0.0 --port 8001 \
+  --metrics
+```
+
+### Deploy to pedrogpt
+
+```bash
+# Deploy presets only
+./scripts/pedrogpt/deploy-presets.sh
+
+# Deploy and activate a preset
+./scripts/pedrogpt/deploy-presets.sh --preset all
+./scripts/pedrogpt/deploy-presets.sh --preset text
+./scripts/pedrogpt/deploy-presets.sh --preset code
+```
+
+## Downloading Models
+
+Models live in `/opt/models/` on pedrogpt. Download with `huggingface-cli`:
+
+```bash
+pip install huggingface_hub hf_transfer
+
+# Text
+hf download unsloth/gpt-oss-20b-GGUF \
+  --include "*Q4_K_M*" \
+  --local-dir /opt/models/gpt-oss-20b
+
+# Text (heavy)
+hf download unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF \
+  --include "*UD-Q4_K_XL*" \
+  --local-dir /opt/models/nemotron-3-super-120b
+
+# Coding
+hf download unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF \
+  --include "*UD-Q4_K_XL*" \
+  --local-dir /opt/models/qwen3-next-80b
+
+# Coding (lite)
+hf download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF \
+  --include "*Q4_K_M*" \
+  --local-dir /opt/models/qwen3-coder-30b
+
+# Vision
+hf download Qwen/Qwen2.5-VL-32B-Instruct-GGUF \
+  --include "*Q4_K_M*" \
+  --local-dir /opt/models/qwen2.5-vl-32b
+
+# TTS
+hf download Qwen/Qwen2.5-Omni-7B-GGUF \
+  --local-dir /opt/models/qwen2.5-omni-7b
+```
+
+If downloads get stuck, set `HF_HUB_ENABLE_HF_TRANSFER=1` for faster transfers.
+
+## Finding New Models
+
+### Step 1: Check LiveBench scores
+
+Go to [LiveBench](https://livebench.ai/#/?highunseenbias=true) to find
+top-performing models:
+
+1. Enable **"High Unseen Bias"** to filter for models tested on unseen data
+2. Sort by **Overall** or by category (Coding, Reasoning, Math, etc.)
+3. Look for open-weight models — MoE with low active params are ideal
+4. Note the model name (e.g., "Qwen3-Next-80B-A3B")
+
+### Step 2: Find GGUF quantizations on HuggingFace
+
+1. Go to [HuggingFace](https://huggingface.co)
+2. Search for `<model-name> GGUF` (e.g., "Qwen3-Next-80B-A3B GGUF")
+3. Look for repos by **unsloth** or **bartowski** — they provide reliable quants
+4. For MoE models, prefer **UD-Q4_K_XL** (unsloth dynamic quant) — applies
+   higher precision to important layers automatically
+5. Quant sizing guide:
+
+| Quantization | Quality | Notes |
+|-------------|---------|-------|
+| UD-Q4_K_XL | Excellent | Unsloth dynamic quant, best for MoE |
+| UD-Q2_K_XL | Good | Unsloth dynamic 2-bit, smaller |
+| Q8_0 | Near-lossless | ~1.1x active params in GB |
+| Q6_K | Excellent | ~0.85x active params in GB |
+| Q5_K_M | Very good | ~0.73x active params in GB |
+| Q4_K_M | Good | ~0.6x active params in GB |
+
+### Step 3: Size for pedrogpt
+
+**32GB VRAM:**
+- **Dense**: Up to ~25B at Q4_K_M, ~20B at Q8_0
+- **MoE**: 80-120B+ total params — only active params matter.
+  Use `-ot ".ffn_.*_exps.=CPU"` to put experts in 64GB RAM.
+- **Context**: Use `--flash-attn` to push to 64K+ on small-active MoE models.
+
+**64GB system RAM:**
+- Offload MoE experts: `-ot ".ffn_.*_exps.=CPU"`
+- KV cache spills to RAM for long contexts
+- Set `n-gpu-layers` to control GPU/RAM split
+
+### Step 4: Add to a preset and deploy
+
+1. Download the model:
+
+```bash
+hf download org/new-model-GGUF \
+  --include "*Q4_K_M*" \
+  --local-dir /opt/models/new-model
+```
+
+2. Add a section to the relevant preset INI:
+
+```ini
+[new-model]
+model = /opt/models/new-model/new-model-Q4_K_M.gguf
+ctx-size = 16384
+```
+
+3. Deploy and test:
+
+```bash
+./scripts/pedrogpt/deploy-presets.sh --preset all
+
+curl http://pedrogpt:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "new-model", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+## Preset INI Format Reference
+
+```ini
+version = 1
+
+# Global defaults (apply to all models unless overridden)
+[*]
+n-gpu-layers = -1
+ctx-size = 8192
+jinja = true
+
+# Model section — the section name is what you pass as "model" in API requests
+[my-model-name]
+model = /opt/models/my-model/my-model-Q4_K_M.gguf
+ctx-size = 16384                # Context size
+n-gpu-layers = 99               # GPU layer count (-1 = all)
+flash-attn = true               # Flash attention
+load-on-startup = true          # Auto-load when server starts
+stop-timeout = 30               # Seconds before force-kill on swap
+chat-template = chatml          # Override chat template
+temp = 0.6                      # Sampling temperature
+top-p = 0.95                    # Top-p sampling
+model-draft = /path/to.gguf     # Speculative decoding draft model
+```
+
+Keys correspond to llama-server CLI args (without leading `--`).
+Both short forms (`c`, `ngl`) and env var names (`LLAMA_ARG_N_GPU_LAYERS`) work.
+
+**Note:** Router-level args (`--host`, `--port`, `-ot`) go on the CLI, not in
+the INI. The INI defines per-model settings only.

--- a/scripts/pedrogpt/presets/all-models.ini
+++ b/scripts/pedrogpt/presets/all-models.ini
@@ -1,0 +1,53 @@
+# llama.cpp model preset: All pedro models (router mode)
+# Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
+#
+# Combined preset for llama-server router mode (--models-preset).
+# Only one model loads at a time; the router swaps on demand.
+#
+# Usage:
+#   llama-server --models-preset /opt/llama.cpp/presets/all-models.ini --models-max 1
+#
+# Switch models by setting "model" in the API request:
+#   curl .../v1/chat/completions -d '{"model": "gpt-oss-20b", ...}'
+#   curl .../v1/chat/completions -d '{"model": "qwen3-coder-30b", ...}'
+#
+# For MoE expert offload (qwen3-next-80b), add to CLI:
+#   -ot ".ffn_.*_exps.=CPU" --flash-attn
+
+version = 1
+
+[*]
+n-gpu-layers = -1
+ctx-size = 8192
+jinja = true
+stop-timeout = 30
+
+# --- Text (default) ---
+[gpt-oss-20b]
+model = /opt/models/gpt-oss-20b/gpt-oss-20b-Q4_K_M.gguf
+ctx-size = 16384
+load-on-startup = true
+
+# --- Text (heavy reasoning) ---
+[nemotron-3-super-120b]
+model = /opt/models/nemotron-3-super-120b/UD-Q4_K_XL/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_XL-00001-of-00003.gguf
+ctx-size = 16384
+temp = 0.6
+top-p = 0.95
+
+# --- Coding ---
+[qwen3-next-80b]
+model = /opt/models/qwen3-next-80b/UD-Q4_K_XL/Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL-00001-of-00003.gguf
+n-gpu-layers = 99
+ctx-size = 65536
+flash-attn = true
+
+# --- Coding (lite) ---
+[qwen3-coder-30b]
+model = /opt/models/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
+ctx-size = 32768
+
+# --- Vision ---
+[qwen2.5-vl-32b]
+model = /opt/models/qwen2.5-vl-32b/qwen2.5-vl-32b-instruct-q4_k_m.gguf
+ctx-size = 8192

--- a/scripts/pedrogpt/presets/all-models.ini
+++ b/scripts/pedrogpt/presets/all-models.ini
@@ -11,8 +11,9 @@
 #   curl .../v1/chat/completions -d '{"model": "gpt-oss-20b", ...}'
 #   curl .../v1/chat/completions -d '{"model": "qwen3-coder-30b", ...}'
 #
-# For MoE expert offload (qwen3-next-80b), add to CLI:
+# For MoE expert offload (qwen3-next-80b, nemotron-3-super-120b), add to CLI:
 #   -ot ".ffn_.*_exps.=CPU" --flash-attn
+# Without this, large MoE models will OOM on 32GB VRAM and fail to load.
 
 version = 1
 
@@ -25,13 +26,15 @@ stop-timeout = 30
 # --- Text (default) ---
 [gpt-oss-20b]
 model = /opt/models/gpt-oss-20b/gpt-oss-20b-Q4_K_M.gguf
-ctx-size = 16384
+ctx-size = 32768
 load-on-startup = true
 
 # --- Text (heavy reasoning) ---
+# REQUIRES CLI: -ot ".ffn_.*_exps.=CPU" --flash-attn to offload expert layers to 64GB RAM
 [nemotron-3-super-120b]
 model = /opt/models/nemotron-3-super-120b/UD-Q4_K_XL/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_XL-00001-of-00003.gguf
-ctx-size = 16384
+ctx-size = 131072
+flash-attn = true
 temp = 0.6
 top-p = 0.95
 
@@ -39,15 +42,15 @@ top-p = 0.95
 [qwen3-next-80b]
 model = /opt/models/qwen3-next-80b/UD-Q4_K_XL/Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL-00001-of-00003.gguf
 n-gpu-layers = 99
-ctx-size = 65536
+ctx-size = 131072
 flash-attn = true
 
 # --- Coding (lite) ---
 [qwen3-coder-30b]
 model = /opt/models/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
-ctx-size = 32768
+ctx-size = 131072
 
 # --- Vision ---
 [qwen2.5-vl-32b]
 model = /opt/models/qwen2.5-vl-32b/qwen2.5-vl-32b-instruct-q4_k_m.gguf
-ctx-size = 8192
+ctx-size = 32768

--- a/scripts/pedrogpt/presets/all-models.ini
+++ b/scripts/pedrogpt/presets/all-models.ini
@@ -30,7 +30,8 @@ ctx-size = 32768
 load-on-startup = true
 
 # --- Text (heavy reasoning) ---
-# REQUIRES CLI: -ot ".ffn_.*_exps.=CPU" --flash-attn to offload expert layers to 64GB RAM
+# MoE 120B model (12B active), Q4_K_XL (~78 GB). Full expert offload to 64GB RAM.
+# REQUIRES CLI: -ot ".ffn_.*_exps.=CPU" --flash-attn
 [nemotron-3-super-120b]
 model = /opt/models/nemotron-3-super-120b/UD-Q4_K_XL/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_XL-00001-of-00003.gguf
 ctx-size = 131072

--- a/scripts/pedrogpt/presets/code.ini
+++ b/scripts/pedrogpt/presets/code.ini
@@ -1,0 +1,32 @@
+# llama.cpp model preset: Coding model
+# Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
+#
+# Primary: Qwen3-Next 80B-A3B — MoE (3B active), 64K context.
+# Use -ot ".ffn_.*_exps.=CPU" on the CLI to offload expert layers to 64GB RAM.
+#
+# Alternative: Qwen3-Coder 30B-A3B — smaller MoE, fully GPU-resident.
+#
+# Download models first:
+#   hf download unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF --include "*UD-Q4_K_XL*" --local-dir /opt/models/qwen3-next-80b
+#   hf download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF --include "*Q4_K_M*" --local-dir /opt/models/qwen3-coder-30b
+#
+# LiveBench: https://livebench.ai/#/?highunseenbias=true
+
+version = 1
+
+[*]
+n-gpu-layers = -1
+ctx-size = 8192
+jinja = true
+
+[qwen3-next-80b]
+# MoE 80B total, 3B active — use with -ot ".ffn_.*_exps.=CPU" --flash-attn
+model = /opt/models/qwen3-next-80b/UD-Q4_K_XL/Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL-00001-of-00003.gguf
+n-gpu-layers = 99
+ctx-size = 65536
+flash-attn = true
+
+[qwen3-coder-30b]
+# 18.6 GB — fits fully in VRAM, no expert offloading needed
+model = /opt/models/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
+ctx-size = 32768

--- a/scripts/pedrogpt/presets/code.ini
+++ b/scripts/pedrogpt/presets/code.ini
@@ -1,7 +1,7 @@
 # llama.cpp model preset: Coding model
 # Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
 #
-# Primary: Qwen3-Next 80B-A3B — MoE (3B active), 64K context.
+# Primary: Qwen3-Next 80B-A3B — MoE (3B active), 128K context.
 # Use -ot ".ffn_.*_exps.=CPU" on the CLI to offload expert layers to 64GB RAM.
 #
 # Alternative: Qwen3-Coder 30B-A3B — smaller MoE, fully GPU-resident.
@@ -23,10 +23,10 @@ jinja = true
 # MoE 80B total, 3B active — use with -ot ".ffn_.*_exps.=CPU" --flash-attn
 model = /opt/models/qwen3-next-80b/UD-Q4_K_XL/Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL-00001-of-00003.gguf
 n-gpu-layers = 99
-ctx-size = 65536
+ctx-size = 131072
 flash-attn = true
 
 [qwen3-coder-30b]
 # 18.6 GB — fits fully in VRAM, no expert offloading needed
 model = /opt/models/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
-ctx-size = 32768
+ctx-size = 131072

--- a/scripts/pedrogpt/presets/text.ini
+++ b/scripts/pedrogpt/presets/text.ini
@@ -1,0 +1,31 @@
+# llama.cpp model preset: General-purpose text model
+# Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
+#
+# Primary: GPT-OSS 20B — dense text model, fast and fully GPU-resident.
+# Alternative: Nemotron-3-Super 120B-A12B — MoE (12B active), heavier reasoning.
+#
+# Download models first:
+#   hf download unsloth/gpt-oss-20b-GGUF --include "*Q4_K_M*" --local-dir /opt/models/gpt-oss-20b
+#   hf download unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF --include "*UD-Q4_K_XL*" --local-dir /opt/models/nemotron-3-super-120b
+#
+# LiveBench: https://livebench.ai/#/?highunseenbias=true
+
+version = 1
+
+[*]
+n-gpu-layers = -1
+ctx-size = 8192
+jinja = true
+
+[gpt-oss-20b]
+# 11.6 GB — fastest, fits fully in VRAM with room to spare
+model = /opt/models/gpt-oss-20b/gpt-oss-20b-Q4_K_M.gguf
+ctx-size = 16384
+load-on-startup = true
+
+[nemotron-3-super-120b]
+# MoE 120B total, 12B active — strong reasoning
+model = /opt/models/nemotron-3-super-120b/UD-Q4_K_XL/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_XL-00001-of-00003.gguf
+ctx-size = 16384
+temp = 0.6
+top-p = 0.95

--- a/scripts/pedrogpt/presets/text.ini
+++ b/scripts/pedrogpt/presets/text.ini
@@ -8,7 +8,7 @@
 #
 # Download models first:
 #   hf download unsloth/gpt-oss-20b-GGUF --include "*Q4_K_M*" --local-dir /opt/models/gpt-oss-20b
-#   hf download unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF --include "*UD-Q4_K_XL*" --local-dir /opt/models/nemotron-3-super-120b
+#   hf download unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF --include "*Q3_K_M*" --local-dir /opt/models/nemotron-3-super-120b/Q3_K_M
 #
 # LiveBench: https://livebench.ai/#/?highunseenbias=true
 
@@ -26,9 +26,13 @@ ctx-size = 32768
 load-on-startup = true
 
 [nemotron-3-super-120b]
-# MoE 120B total, 12B active — strong reasoning; launch with -ot ".ffn_.*_exps.=CPU" --flash-attn
-model = /opt/models/nemotron-3-super-120b/UD-Q4_K_XL/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_XL-00001-of-00003.gguf
+# MoE 120B total, 12B active — strong reasoning. Q3_K_M (~52 GB) fits RAM better than Q4_K_XL (~77 GB).
+# Requires full expert offload: -ot ".ffn_.*_exps.=CPU" --flash-attn
+model = /opt/models/nemotron-3-super-120b/Q3_K_M/UD-Q3_K_M/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q3_K_M-00001-of-00003.gguf
 ctx-size = 131072
 flash-attn = true
+no-mmap = true
+parallel = 1
+override-tensor = .ffn_.*_exps.=CPU
 temp = 0.6
 top-p = 0.95

--- a/scripts/pedrogpt/presets/text.ini
+++ b/scripts/pedrogpt/presets/text.ini
@@ -3,6 +3,8 @@
 #
 # Primary: GPT-OSS 20B — dense text model, fast and fully GPU-resident.
 # Alternative: Nemotron-3-Super 120B-A12B — MoE (12B active), heavier reasoning.
+#   Nemotron REQUIRES expert offload on the CLI: -ot ".ffn_.*_exps.=CPU" --flash-attn
+#   Without it, the model will fail to load (OOM on 32GB VRAM).
 #
 # Download models first:
 #   hf download unsloth/gpt-oss-20b-GGUF --include "*Q4_K_M*" --local-dir /opt/models/gpt-oss-20b
@@ -20,12 +22,13 @@ jinja = true
 [gpt-oss-20b]
 # 11.6 GB — fastest, fits fully in VRAM with room to spare
 model = /opt/models/gpt-oss-20b/gpt-oss-20b-Q4_K_M.gguf
-ctx-size = 16384
+ctx-size = 32768
 load-on-startup = true
 
 [nemotron-3-super-120b]
-# MoE 120B total, 12B active — strong reasoning
+# MoE 120B total, 12B active — strong reasoning; launch with -ot ".ffn_.*_exps.=CPU" --flash-attn
 model = /opt/models/nemotron-3-super-120b/UD-Q4_K_XL/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_XL-00001-of-00003.gguf
-ctx-size = 16384
+ctx-size = 131072
+flash-attn = true
 temp = 0.6
 top-p = 0.95

--- a/scripts/pedrogpt/presets/tts.ini
+++ b/scripts/pedrogpt/presets/tts.ini
@@ -1,0 +1,19 @@
+# llama.cpp model preset: Text-to-Speech (TTS) model
+# Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
+#
+# Qwen2.5-Omni 7B — multimodal model with TTS capabilities.
+# Run as a separate llama-server process on port 8001.
+#
+# Download model first:
+#   hf download Qwen/Qwen2.5-Omni-7B-GGUF --local-dir /opt/models/qwen2.5-omni-7b
+
+version = 1
+
+[*]
+n-gpu-layers = 99
+jinja = true
+
+[qwen2.5-omni-7b]
+# ~8 GB — lightweight, leaves VRAM headroom for the primary model
+model = /opt/models/qwen2.5-omni-7b/qwen2.5-omni-7b.gguf
+ctx-size = 8192

--- a/scripts/pedrogpt/presets/tts.ini
+++ b/scripts/pedrogpt/presets/tts.ini
@@ -16,4 +16,4 @@ jinja = true
 [qwen2.5-omni-7b]
 # ~8 GB — lightweight, leaves VRAM headroom for the primary model
 model = /opt/models/qwen2.5-omni-7b/qwen2.5-omni-7b.gguf
-ctx-size = 8192
+ctx-size = 32768

--- a/scripts/pedrogpt/presets/vision.ini
+++ b/scripts/pedrogpt/presets/vision.ini
@@ -1,0 +1,27 @@
+# llama.cpp model preset: Vision (text + image) model
+# Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
+#
+# Qwen2.5-VL 32B — multimodal vision-language model.
+# Handles image understanding, OCR, diagram analysis, and visual QA.
+#
+# Download model first:
+#   hf download Qwen/Qwen2.5-VL-32B-Instruct-GGUF --include "*Q4_K_M*" --local-dir /opt/models/qwen2.5-vl-32b
+#
+# LiveBench: https://livebench.ai/#/?highunseenbias=true
+
+version = 1
+
+[*]
+n-gpu-layers = -1
+ctx-size = 4096
+jinja = true
+
+[qwen2.5-vl-32b]
+# ~18 GB — fits in VRAM, strong vision capabilities
+model = /opt/models/qwen2.5-vl-32b/qwen2.5-vl-32b-instruct-q4_k_m.gguf
+ctx-size = 8192
+
+[qwen2.5-vl-7b]
+# ~8 GB — lighter alternative, faster inference
+model = /opt/models/qwen2.5-vl-7b/qwen2.5-vl-7b-instruct-q8_0.gguf
+ctx-size = 8192

--- a/scripts/pedrogpt/presets/vision.ini
+++ b/scripts/pedrogpt/presets/vision.ini
@@ -19,9 +19,9 @@ jinja = true
 [qwen2.5-vl-32b]
 # ~18 GB — fits in VRAM, strong vision capabilities
 model = /opt/models/qwen2.5-vl-32b/qwen2.5-vl-32b-instruct-q4_k_m.gguf
-ctx-size = 8192
+ctx-size = 32768
 
 [qwen2.5-vl-7b]
 # ~8 GB — lighter alternative, faster inference
 model = /opt/models/qwen2.5-vl-7b/qwen2.5-vl-7b-instruct-q8_0.gguf
-ctx-size = 8192
+ctx-size = 32768

--- a/scripts/pedrogpt/rebuild-llama-cpp.sh
+++ b/scripts/pedrogpt/rebuild-llama-cpp.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Rebuild llama.cpp on pedrogpt with CUDA support.
+#
+# Run locally (over SSH) or directly on pedrogpt.
+#
+# Usage:
+#   ./rebuild-llama-cpp.sh              # Build from this machine via SSH
+#   ./rebuild-llama-cpp.sh --local      # Run directly on pedrogpt
+#   ./rebuild-llama-cpp.sh --arch 89    # Override CUDA architecture (default: auto-detect)
+
+set -euo pipefail
+
+LLAMA_DIR="/opt/llama.cpp"
+REMOTE_HOST="pedrogpt"
+CUDA_ARCH=""
+LOCAL=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --local)  LOCAL=true; shift ;;
+    --arch)   CUDA_ARCH="$2"; shift 2 ;;
+    --host)   REMOTE_HOST="$2"; shift 2 ;;
+    -h|--help)
+      head -9 "$0" | tail -7
+      exit 0
+      ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Build function — runs on pedrogpt
+# ---------------------------------------------------------------------------
+do_build() {
+  local arch="$1"
+
+  # Auto-detect CUDA architecture if not specified
+  if [[ -z "$arch" ]]; then
+    if command -v nvidia-smi &>/dev/null; then
+      local compute
+      compute=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1 | tr -d '.')
+      arch="$compute"
+      echo "Auto-detected CUDA architecture: sm_$arch"
+    else
+      echo "ERROR: Cannot detect GPU. Specify --arch manually (e.g., --arch 89 or --arch 120)"
+      exit 1
+    fi
+  fi
+
+  echo "=== Rebuilding llama.cpp (CUDA arch: sm_$arch) ==="
+  echo ""
+
+  cd "$LLAMA_DIR"
+
+  echo "--- Pulling latest source ---"
+  sudo git config --global --add safe.directory "$LLAMA_DIR" 2>/dev/null || true
+  sudo git pull
+
+  echo ""
+  echo "--- CUDA toolkit ---"
+  nvcc --version
+
+  echo ""
+  echo "--- Building (this may take a few minutes) ---"
+  sudo cmake -B build -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="$arch"
+  sudo cmake --build build --config Release -j"$(nproc)"
+
+  echo ""
+  echo "--- Verifying ---"
+  "$LLAMA_DIR/build/bin/llama-server" --version
+
+  echo ""
+  echo "--- Restarting llama-server ---"
+  sudo systemctl restart llama-server
+  sleep 3
+
+  if sudo systemctl is-active --quiet llama-server; then
+    echo "=== Build complete, llama-server running ==="
+  else
+    echo "WARNING: llama-server failed to start after rebuild"
+    sudo journalctl -u llama-server -n 20 --no-pager
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run locally on pedrogpt or remotely via SSH
+# ---------------------------------------------------------------------------
+if [[ "$LOCAL" == "true" ]]; then
+  do_build "$CUDA_ARCH"
+else
+  echo "=== Rebuilding llama.cpp on $REMOTE_HOST via SSH ==="
+  # Export the function and run it remotely
+  ARCH_ARG=""
+  [[ -n "$CUDA_ARCH" ]] && ARCH_ARG="--arch $CUDA_ARCH"
+  scp "$0" "$REMOTE_HOST:/tmp/rebuild-llama-cpp.sh"
+  ssh -t "$REMOTE_HOST" "bash /tmp/rebuild-llama-cpp.sh --local $ARCH_ARG"
+fi

--- a/scripts/pedrogpt/setup-llama-cpp.sh
+++ b/scripts/pedrogpt/setup-llama-cpp.sh
@@ -187,11 +187,63 @@ PORT=8080
 
 # HuggingFace token (required for model downloads — keep this file root-only)
 HF_TOKEN=your_token_here
+
+# MoE expert layer offload pattern (set by switch-model.sh for MoE models).
+# Keeps expert weight tensors in 64GB RAM instead of VRAM — required for
+# models like Qwen3-Next-80B and Nemotron-120B to avoid OOM on 32GB VRAM.
+# Leave empty for dense models (gpt-oss-20b, etc).
+OVERRIDE_TENSOR=
 EOF
   echo "Edit $ENV_FILE before starting the service."
 else
   echo "--- $ENV_FILE already exists, skipping ---"
+  # Add OVERRIDE_TENSOR to existing env file if missing
+  if ! grep -q "^OVERRIDE_TENSOR" "$ENV_FILE"; then
+    echo "" | sudo tee -a "$ENV_FILE" > /dev/null
+    echo "# MoE expert layer offload — set by switch-model.sh for MoE models, leave empty for dense" | sudo tee -a "$ENV_FILE" > /dev/null
+    echo "OVERRIDE_TENSOR=" | sudo tee -a "$ENV_FILE" > /dev/null
+    echo "Added OVERRIDE_TENSOR to existing $ENV_FILE"
+  fi
 fi
+
+# ---------------------------------------------------------------------------
+# Wrapper script — handles optional --override-tensor for MoE models.
+# Systemd ExecStart can't do conditional args, so we use a launcher script.
+# ---------------------------------------------------------------------------
+WRAPPER="$LLAMA_DIR/run-server.sh"
+echo "--- Installing launcher wrapper $WRAPPER ---"
+sudo tee "$WRAPPER" > /dev/null <<'WRAPPER_EOF'
+#!/bin/bash
+# llama-server launcher — reads /etc/llama-server.env and starts the server.
+# Called by the llama-server systemd service.
+set -euo pipefail
+
+ENV_FILE="/etc/llama-server.env"
+# shellcheck source=/etc/llama-server.env
+source "$ENV_FILE"
+
+export HF_HOME="${HF_HOME:-/opt/models/cache}"
+export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN:-}"
+
+OVERRIDE_ARGS=()
+if [[ -n "${OVERRIDE_TENSOR:-}" ]]; then
+  OVERRIDE_ARGS=(--override-tensor "${OVERRIDE_TENSOR}")
+fi
+
+exec /opt/llama.cpp/build/bin/llama-server \
+    --host 0.0.0.0 \
+    --port "${PORT:-8080}" \
+    --hf-repo "${HF_REPO}" \
+    --hf-file "${HF_FILE}" \
+    --ctx-size "${N_CTX:-8192}" \
+    --n-gpu-layers "${N_GPU_LAYERS:--1}" \
+    --parallel "${N_PARALLEL:-4}" \
+    --jinja \
+    --no-webui \
+    --metrics \
+    "${OVERRIDE_ARGS[@]}"
+WRAPPER_EOF
+sudo chmod +x "$WRAPPER"
 
 # ---------------------------------------------------------------------------
 # Systemd service
@@ -206,19 +258,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-EnvironmentFile=$ENV_FILE
-ExecStart=$LLAMA_DIR/build/bin/llama-server \\
-    --host 0.0.0.0 \\
-    --port \${PORT} \\
-    --hf-repo \${HF_REPO} \\
-    --hf-file \${HF_FILE} \\
-    --ctx-size \${N_CTX} \\
-    --n-gpu-layers \${N_GPU_LAYERS} \\
-    --parallel \${N_PARALLEL} \\
-    --jinja \\
-    --no-webui \\
-    --metrics
-Environment=HF_HOME=\${HF_HOME}
+ExecStart=$LLAMA_DIR/run-server.sh
 Restart=on-failure
 RestartSec=10
 StandardOutput=journal

--- a/scripts/pedrogpt/setup-llama-cpp.sh
+++ b/scripts/pedrogpt/setup-llama-cpp.sh
@@ -193,6 +193,12 @@ HF_TOKEN=your_token_here
 # models like Qwen3-Next-80B and Nemotron-120B to avoid OOM on 32GB VRAM.
 # Leave empty for dense models (gpt-oss-20b, etc).
 OVERRIDE_TENSOR=
+
+# Flash attention (set by switch-model.sh for MoE models).
+# Reduces KV cache VRAM usage — required alongside OVERRIDE_TENSOR for large
+# MoE models (Nemotron-120B, Qwen3-Next-80B) to avoid OOM on 32GB VRAM.
+# Set to 1 for MoE models, leave empty for dense models.
+FLASH_ATTN=
 EOF
   echo "Edit $ENV_FILE before starting the service."
 else
@@ -203,6 +209,13 @@ else
     echo "# MoE expert layer offload — set by switch-model.sh for MoE models, leave empty for dense" | sudo tee -a "$ENV_FILE" > /dev/null
     echo "OVERRIDE_TENSOR=" | sudo tee -a "$ENV_FILE" > /dev/null
     echo "Added OVERRIDE_TENSOR to existing $ENV_FILE"
+  fi
+  # Add FLASH_ATTN to existing env file if missing
+  if ! grep -q "^FLASH_ATTN" "$ENV_FILE"; then
+    echo "" | sudo tee -a "$ENV_FILE" > /dev/null
+    echo "# Flash attention — set by switch-model.sh for MoE models, leave empty for dense" | sudo tee -a "$ENV_FILE" > /dev/null
+    echo "FLASH_ATTN=" | sudo tee -a "$ENV_FILE" > /dev/null
+    echo "Added FLASH_ATTN to existing $ENV_FILE"
   fi
 fi
 
@@ -225,9 +238,12 @@ source "$ENV_FILE"
 export HF_HOME="${HF_HOME:-/opt/models/cache}"
 export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN:-}"
 
-OVERRIDE_ARGS=()
+EXTRA_ARGS=()
 if [[ -n "${OVERRIDE_TENSOR:-}" ]]; then
-  OVERRIDE_ARGS=(--override-tensor "${OVERRIDE_TENSOR}")
+  EXTRA_ARGS+=(--override-tensor "${OVERRIDE_TENSOR}")
+fi
+if [[ "${FLASH_ATTN:-}" == "1" ]]; then
+  EXTRA_ARGS+=(--flash-attn)
 fi
 
 exec /opt/llama.cpp/build/bin/llama-server \
@@ -241,7 +257,7 @@ exec /opt/llama.cpp/build/bin/llama-server \
     --jinja \
     --no-webui \
     --metrics \
-    "${OVERRIDE_ARGS[@]}"
+    "${EXTRA_ARGS[@]}"
 WRAPPER_EOF
 sudo chmod +x "$WRAPPER"
 

--- a/scripts/pedrogpt/switch-model.sh
+++ b/scripts/pedrogpt/switch-model.sh
@@ -8,9 +8,11 @@
 # pedrogpt hardware: 32GB VRAM + 64GB RAM
 #
 # pedro models (verified):
-#   unsloth/gpt-oss-20b-GGUF                       gpt-oss-20b-Q4_K_M.gguf          11.6 GB
-#   unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF      Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf  18.6 GB MoE
-#   unsloth/Qwen3.5-35B-A3B-GGUF                   Qwen3.5-35B-A3B-Q4_K_M.gguf      21.2 GB MoE
+#   unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF  UD-Q4_K_XL (multi-file)           MoE 12B active
+#   unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF        UD-Q4_K_XL (multi-file)           MoE 3B active
+#   unsloth/gpt-oss-20b-GGUF                        gpt-oss-20b-Q4_K_M.gguf          11.6 GB
+#   unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF       Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf  18.6 GB MoE
+#   unsloth/Qwen3.5-35B-A3B-GGUF                    Qwen3.5-35B-A3B-Q4_K_M.gguf      21.2 GB MoE
 #
 # Usage:
 #   ./switch-model.sh <hf-repo> <hf-file>
@@ -31,6 +33,13 @@ SUBCOMMAND="${1:-}"
 # ---------------------------------------------------------------------------
 if [[ "$SUBCOMMAND" == "list" ]]; then
   echo "pedro models:"
+  echo ""
+  echo "  unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF"
+  echo "    UD-Q4_K_XL (multi-file)           MoE 120B total, 12B active"
+  echo "    UD-Q2_K_XL (multi-file)           MoE smaller footprint"
+  echo ""
+  echo "  unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF"
+  echo "    UD-Q4_K_XL (multi-file)           MoE 80B total, 3B active"
   echo ""
   echo "  unsloth/gpt-oss-20b-GGUF"
   echo "    gpt-oss-20b-Q4_K_M.gguf          11.6 GB"

--- a/scripts/pedrogpt/switch-model.sh
+++ b/scripts/pedrogpt/switch-model.sh
@@ -80,6 +80,21 @@ if [[ ! -f "$ENV_FILE" ]]; then
   exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# MoE detection — these models need expert layers offloaded to RAM via
+# --override-tensor to avoid OOM on 32GB VRAM.
+# ---------------------------------------------------------------------------
+is_moe_model() {
+  local repo="$1" file="$2"
+  case "$repo" in
+    *Qwen3-Next*|*Qwen3-Coder*|*Qwen3.5*|*Nemotron*Super*|*A3B*|*A12B*) return 0 ;;
+  esac
+  case "$file" in
+    *A3B*|*A12B*|*MoE*|*moe*) return 0 ;;
+  esac
+  return 1
+}
+
 echo "=== Switching model ==="
 echo "Repo: $HF_REPO"
 echo "File: $HF_FILE"
@@ -87,6 +102,21 @@ echo ""
 
 sudo sed -i "s|^HF_REPO=.*|HF_REPO=$HF_REPO|" "$ENV_FILE"
 sudo sed -i "s|^HF_FILE=.*|HF_FILE=$HF_FILE|" "$ENV_FILE"
+
+if is_moe_model "$HF_REPO" "$HF_FILE"; then
+  OVERRIDE_TENSOR=".ffn_.*_exps.=CPU"
+  echo "MoE model detected — setting OVERRIDE_TENSOR=$OVERRIDE_TENSOR"
+  echo "(expert layers will be offloaded to 64GB RAM, attention stays on GPU)"
+else
+  OVERRIDE_TENSOR=""
+  echo "Dense model — OVERRIDE_TENSOR cleared"
+fi
+
+if grep -q "^OVERRIDE_TENSOR" "$ENV_FILE"; then
+  sudo sed -i "s|^OVERRIDE_TENSOR=.*|OVERRIDE_TENSOR=$OVERRIDE_TENSOR|" "$ENV_FILE"
+else
+  echo "OVERRIDE_TENSOR=$OVERRIDE_TENSOR" | sudo tee -a "$ENV_FILE" > /dev/null
+fi
 
 echo "Updated $ENV_FILE"
 echo "Restarting llama-server (will download model if not cached)..."

--- a/scripts/pedrogpt/switch-model.sh
+++ b/scripts/pedrogpt/switch-model.sh
@@ -105,17 +105,25 @@ sudo sed -i "s|^HF_FILE=.*|HF_FILE=$HF_FILE|" "$ENV_FILE"
 
 if is_moe_model "$HF_REPO" "$HF_FILE"; then
   OVERRIDE_TENSOR=".ffn_.*_exps.=CPU"
-  echo "MoE model detected — setting OVERRIDE_TENSOR=$OVERRIDE_TENSOR"
-  echo "(expert layers will be offloaded to 64GB RAM, attention stays on GPU)"
+  FLASH_ATTN="1"
+  echo "MoE model detected — setting OVERRIDE_TENSOR=$OVERRIDE_TENSOR, FLASH_ATTN=1"
+  echo "(expert layers offloaded to 64GB RAM, flash-attn reduces KV cache VRAM)"
 else
   OVERRIDE_TENSOR=""
-  echo "Dense model — OVERRIDE_TENSOR cleared"
+  FLASH_ATTN=""
+  echo "Dense model — OVERRIDE_TENSOR and FLASH_ATTN cleared"
 fi
 
 if grep -q "^OVERRIDE_TENSOR" "$ENV_FILE"; then
   sudo sed -i "s|^OVERRIDE_TENSOR=.*|OVERRIDE_TENSOR=$OVERRIDE_TENSOR|" "$ENV_FILE"
 else
   echo "OVERRIDE_TENSOR=$OVERRIDE_TENSOR" | sudo tee -a "$ENV_FILE" > /dev/null
+fi
+
+if grep -q "^FLASH_ATTN" "$ENV_FILE"; then
+  sudo sed -i "s|^FLASH_ATTN=.*|FLASH_ATTN=$FLASH_ATTN|" "$ENV_FILE"
+else
+  echo "FLASH_ATTN=$FLASH_ATTN" | sudo tee -a "$ENV_FILE" > /dev/null
 fi
 
 echo "Updated $ENV_FILE"


### PR DESCRIPTION
Add preset INI configs for three model categories sized for pedrogpt
(32GB VRAM + 64GB RAM):
- text.ini: GPT-OSS 20B (general chat/reasoning)
- code.ini: Qwen3-Coder 30B-A3B MoE (code generation)
- vision.ini: Qwen2.5-VL 32B (image understanding)
- all-models.ini: Combined router preset for model switching

Includes deploy-presets.sh script that SCPs presets to pedrogpt over
Tailscale, creates a systemd drop-in override for --models-preset,
and restarts the service. Supports Taildrop as an alternative transport.

README documents how to find and evaluate models using LiveBench and
HuggingFace, with sizing guidelines for the hardware.

https://claude.ai/code/session_01B1musvhL2VSXjy16XZuUqr