### PR TITLE
feat: add pedro-embed-server Helm chart

### DIFF
--- a/docs/issues/helm-migration.md
+++ b/docs/issues/helm-migration.md
@@ -1,0 +1,74 @@
+# Migrate k8s manifests to Helm charts
+
+## Problem
+
+The pedro-ops repository currently uses a mix of Kustomize (`k8s/`) and Helm (`helm/`), leading to inconsistency in how applications are deployed.
+
+## Current State
+
+- `k8s/base/` - Uses Kustomize for base manifests
+- `helm/` - Contains some Helm charts (tailscale-ingresses, eleduck-analytics)
+- Applications like embed-server are being added as Helm charts while others remain as Kustomize
+
+## Goal
+
+Migrate all cluster applications to Helm charts, deployed via Foundry CLI or skaffold.
+
+## Benefits
+
+1. **Consistency** - Single deployment mechanism for all applications
+2. **Flexibility** - Helm values allow environment-specific overrides
+3. **Reusability** - Helm charts can be shared or published
+4. **Foundry/skaffold integration** - Both tools work well with Helm
+
+## Scope
+
+### Phase 1: Document current deployment methods
+- [ ] List all current deployments and their methods (kustomize, helm, direct kubectl)
+- [ ] Identify which k8s manifests should become Helm charts
+
+### Phase 2: Migrate k8s/base/ to Helm
+- [ ] Convert namespace.yaml to Helm template (or keep as is)
+- [ ] Move each application from k8s/base/<app>/ to helm/<app>/
+- [ ] Update kustomization.yaml to remove migrated resources
+
+### Phase 3: Update deployment workflow
+- [ ] Update Foundry config to use Helm charts
+- [ ] Or configure skaffold for local development
+- [ ] Document deployment process
+
+### Phase 4: Deprecate k8s/ directory
+- [ ] Remove k8s/base/ once all applications are migrated
+- [ ] Update CLAUDE.md with new deployment instructions
+
+## Example
+
+Before (Kustomize):
+```yaml
+# k8s/base/myapp/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+```
+
+After (Helm):
+```yaml
+# helm/myapp/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "myapp.fullname" . }}
+```
+
+## Priority
+
+1. **High**: Migrate applications that need frequent updates (bot services)
+2. **Medium**: Migrate infrastructure components (monitoring, networking)
+3. **Low**: Migrate one-off resources
+
+## Notes
+
+- The embed-server chart (helm/pedro-embed-server/) is an example of the target format
+- Consider using Helmfile for managing multiple charts if needed
+- Keep production overrides in a separate values file or overlay

--- a/helm/pedro-embed-server/Chart.yaml
+++ b/helm/pedro-embed-server/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: pedro-embed-server
+description: CPU vllm embedding server for mempalace and FAQ
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/helm/pedro-embed-server/templates/_helpers.tpl
+++ b/helm/pedro-embed-server/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pedro-embed-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "pedro-embed-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pedro-embed-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pedro-embed-server.labels" -}}
+helm.sh/chart: {{ include "pedro-embed-server.chart" . }}
+{{ include "pedro-embed-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pedro-embed-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pedro-embed-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/pedro-embed-server/templates/deployment.yaml
+++ b/helm/pedro-embed-server/templates/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pedro-embed-server.fullname" . }}
+  labels:
+    {{- include "pedro-embed-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "pedro-embed-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "pedro-embed-server.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: vllm
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - vllm
+            - serve
+            - {{ .Values.model.name }}
+            - --dtype
+            - {{ .Values.model.dtype }}
+            - --max-model-len
+            - {{ .Values.model.maxModelLen | quote }}
+            - --port
+            - {{ .Values.service.port | quote }}
+            - --host
+            - 0.0.0.0
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 10 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 10 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/pedro-embed-server/templates/deployment.yaml
+++ b/helm/pedro-embed-server/templates/deployment.yaml
@@ -35,9 +35,17 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 10 }}
+            httpGet:
+              path: {{ .Values.livenessProbe.httpGet.path }}
+              port: {{ .Values.livenessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 10 }}
+            httpGet:
+              path: {{ .Values.readinessProbe.httpGet.path }}
+              port: {{ .Values.readinessProbe.httpGet.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/helm/pedro-embed-server/templates/service.yaml
+++ b/helm/pedro-embed-server/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pedro-embed-server.fullname" . }}
+  labels:
+    {{- include "pedro-embed-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "pedro-embed-server.selectorLabels" . | nindent 4 }}

--- a/helm/pedro-embed-server/values.yaml
+++ b/helm/pedro-embed-server/values.yaml
@@ -1,0 +1,44 @@
+replicaCount: 1
+
+image:
+  repository: vllm/vllm-openai
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8081
+
+# Embedding model configuration
+model:
+  name: nomic-ai/nomic-embed-text-v1.5
+  dtype: float16
+  maxModelLen: 2048
+
+resources:
+  requests:
+    cpu: 2
+    memory: 4Gi
+  limits:
+    cpu: 4
+    memory: 8Gi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8081
+  initialDelaySeconds: 30
+  periodSeconds: 60
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8081
+  initialDelaySeconds: 10
+  periodSeconds: 30
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm/pedro-embed-server/values.yaml
+++ b/helm/pedro-embed-server/values.yaml
@@ -27,14 +27,14 @@ livenessProbe:
   httpGet:
     path: /health
     port: 8081
-  initialDelaySeconds: 30
+  initialDelaySeconds: 60
   periodSeconds: 60
 
 readinessProbe:
   httpGet:
     path: /health
     port: 8081
-  initialDelaySeconds: 10
+  initialDelaySeconds: 30
   periodSeconds: 30
 
 nodeSelector: {}

--- a/scripts/pedrogpt/presets/code.ini
+++ b/scripts/pedrogpt/presets/code.ini
@@ -1,0 +1,32 @@
+# llama.cpp model preset: Coding model
+# Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
+#
+# Primary: Qwen3-Next 80B-A3B — MoE (3B active), 64K context.
+# Use -ot ".ffn_.*_exps.=CPU" on the CLI to offload expert layers to 64GB RAM.
+#
+# Alternative: Qwen3-Coder 30B-A3B — smaller MoE, fully GPU-resident.
+#
+# Download models first:
+#   hf download unsloth/Qwen3-Next-80B-A3B-Instruct-GGUF --include "*UD-Q4_K_XL*" --local-dir /opt/models/qwen3-next-80b
+#   hf download unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF --include "*Q4_K_M*" --local-dir /opt/models/qwen3-coder-30b
+#
+# LiveBench: https://livebench.ai/#/?highunseenbias=true
+
+version = 1
+
+[*]
+n-gpu-layers = -1
+ctx-size = 8192
+jinja = true
+
+[qwen3-next-80b]
+# MoE 80B total, 3B active — use with -ot ".ffn_.*_exps.=CPU" --flash-attn
+model = /opt/models/qwen3-next-80b/UD-Q4_K_XL/Qwen3-Next-80B-A3B-Instruct-UD-Q4_K_XL-00001-of-00003.gguf
+n-gpu-layers = 99
+ctx-size = 65536
+flash-attn = true
+
+[qwen3-coder-30b]
+# 18.6 GB — fits fully in VRAM, no expert offloading needed
+model = /opt/models/qwen3-coder-30b/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf
+ctx-size = 32768

--- a/scripts/pedrogpt/presets/text.ini
+++ b/scripts/pedrogpt/presets/text.ini
@@ -1,0 +1,31 @@
+# llama.cpp model preset: General-purpose text model
+# Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
+#
+# Primary: GPT-OSS 20B — dense text model, fast and fully GPU-resident.
+# Alternative: Nemotron-3-Super 120B-A12B — MoE (12B active), heavier reasoning.
+#
+# Download models first:
+#   hf download unsloth/gpt-oss-20b-GGUF --include "*Q4_K_M*" --local-dir /opt/models/gpt-oss-20b
+#   hf download unsloth/NVIDIA-Nemotron-3-Super-120B-A12B-GGUF --include "*UD-Q4_K_XL*" --local-dir /opt/models/nemotron-3-super-120b
+#
+# LiveBench: https://livebench.ai/#/?highunseenbias=true
+
+version = 1
+
+[*]
+n-gpu-layers = -1
+ctx-size = 8192
+jinja = true
+
+[gpt-oss-20b]
+# 11.6 GB — fastest, fits fully in VRAM with room to spare
+model = /opt/models/gpt-oss-20b/gpt-oss-20b-Q4_K_M.gguf
+ctx-size = 16384
+load-on-startup = true
+
+[nemotron-3-super-120b]
+# MoE 120B total, 12B active — strong reasoning
+model = /opt/models/nemotron-3-super-120b/UD-Q4_K_XL/NVIDIA-Nemotron-3-Super-120B-A12B-UD-Q4_K_XL-00001-of-00003.gguf
+ctx-size = 16384
+temp = 0.6
+top-p = 0.95

--- a/scripts/pedrogpt/presets/tts.ini
+++ b/scripts/pedrogpt/presets/tts.ini
@@ -1,0 +1,19 @@
+# llama.cpp model preset: Text-to-Speech (TTS) model
+# Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
+#
+# Qwen2.5-Omni 7B — multimodal model with TTS capabilities.
+# Run as a separate llama-server process on port 8001.
+#
+# Download model first:
+#   hf download Qwen/Qwen2.5-Omni-7B-GGUF --local-dir /opt/models/qwen2.5-omni-7b
+
+version = 1
+
+[*]
+n-gpu-layers = 99
+jinja = true
+
+[qwen2.5-omni-7b]
+# ~8 GB — lightweight, leaves VRAM headroom for the primary model
+model = /opt/models/qwen2.5-omni-7b/qwen2.5-omni-7b.gguf
+ctx-size = 8192

--- a/scripts/pedrogpt/presets/vision.ini
+++ b/scripts/pedrogpt/presets/vision.ini
@@ -1,0 +1,27 @@
+# llama.cpp model preset: Vision (text + image) model
+# Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
+#
+# Qwen2.5-VL 32B — multimodal vision-language model.
+# Handles image understanding, OCR, diagram analysis, and visual QA.
+#
+# Download model first:
+#   hf download Qwen/Qwen2.5-VL-32B-Instruct-GGUF --include "*Q4_K_M*" --local-dir /opt/models/qwen2.5-vl-32b
+#
+# LiveBench: https://livebench.ai/#/?highunseenbias=true
+
+version = 1
+
+[*]
+n-gpu-layers = -1
+ctx-size = 4096
+jinja = true
+
+[qwen2.5-vl-32b]
+# ~18 GB — fits in VRAM, strong vision capabilities
+model = /opt/models/qwen2.5-vl-32b/qwen2.5-vl-32b-instruct-q4_k_m.gguf
+ctx-size = 8192
+
+[qwen2.5-vl-7b]
+# ~8 GB — lighter alternative, faster inference
+model = /opt/models/qwen2.5-vl-7b/qwen2.5-vl-7b-instruct-q8_0.gguf
+ctx-size = 8192


### PR DESCRIPTION
## Summary

Add a Helm chart for the CPU vllm embedding server that serves  on port 8081.

This embedding server will be used by:
- MemPalace (for ontology indexing and address detection)
- FAQ service (for semantic matching)

## Changes

- Add  with:
  - Deployment running vllm with CPU-only resources
  - ClusterIP service on port 8081
  - Configurable model, resources, and probes
- Add  as a tracking issue for migrating remaining k8s manifests to Helm

## Why

The MTP chat server (pedrogpt:8000) crashes when embeddings are enabled due to graph incompatibility. This separate embedding server provides a dedicated CPU endpoint for embeddings without affecting chat performance.

## Test plan

1. Deploy helm chart: 
2. Wait for pod to be ready (vllm downloads model from HuggingFace on first run)
3. Test health endpoint: 
4. Test embedding: 

Co-Authored-By: Claude Opus 1M <noreply@anthropic.com>