### PR TITLE
Add OpenWebUI deployment with PostgreSQL, Redis, and Tailscale ingress

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -599,6 +599,20 @@ To achieve full HA:
 - Network bandwidth limited by physical network
 - Control plane is not HA (single node)
 
+## Helm Chart Guidelines
+
+### Node Scheduling
+**Do not use `nodeSelector` to restrict pods to control-plane nodes.** Our cluster has:
+- 1 control-plane node (blue1): 4 cores, 16GB RAM
+- 2 worker nodes (blue2, refurb): 4 and 8 cores respectively
+
+The control-plane node is not specially provisioned for GPU workloads. All worker nodes have sufficient resources. Using `nodeSelector: node-role.kubernetes.io/control-plane: "true"` will:
+- Fail to schedule due to resource constraints
+- Prevent workload distribution across the cluster
+- Create unnecessary contention with infrastructure services
+
+**Correct approach:** Let the scheduler decide based on available resources. Only use nodeSelector when a specific node attribute is required (e.g., dedicated GPU nodes, specific storage).
+
 ## Technology Decisions
 
 ### Why K3s?

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,303 @@
+# Pedro Ops Maintenance Guide
+
+## Overview
+
+This document covers operational maintenance tasks for the Pedro Ops Kubernetes cluster.
+
+## Storage Overview
+
+| Service | Storage Type | PVC | Size | Location |
+|---------|-------------|-----|------|----------|
+| PostgreSQL (OpenWebUI) | Longhorn | openwebui-db-1, openwebui-db-2 | 10Gi each | Worker-1 2TB drive |
+| SeaweedFS | Longhorn | data-seaweedfs-volume-0 | 50Gi | Worker-1 2TB drive |
+| Prometheus | Longhorn | prometheus-... | 200Gi | Worker-1 2TB drive |
+| Grafana | Longhorn | grafana | 5Gi | Worker-1 2TB drive |
+| Loki | Longhorn | storage-loki-0 | 10Gi | Worker-1 2TB drive |
+
+## Backup & Restore
+
+### PostgreSQL (OpenWebUI)
+
+The OpenWebUI database runs on CloudNativePG with 2 replicas on Longhorn storage.
+
+**Manual Backup (Longhorn Snapshots):**
+```bash
+./scripts/backup-openwebui-pg.sh
+```
+
+This creates VolumeSnapshots for both PostgreSQL PVCs.
+
+**List Snapshots:**
+```bash
+kubectl get volumesnapshot -n openwebui
+```
+
+**Restore from Snapshot:**
+```bash
+# Create new PVC from snapshot
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openwebui-db-restore
+  namespace: openwebui
+spec:
+  dataSource:
+    name: <snapshot-name>
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+EOF
+```
+
+### Longhorn Backups
+
+Longhorn has built-in backup to NFS/S3. Configure in Longhorn UI.
+
+```bash
+# Access Longhorn UI
+kubectl port-forward -n longhorn-system svc/longhorn-frontend 7000:80
+```
+
+## Upgrades
+
+### OpenWebUI
+```bash
+helm repo update
+helm upgrade openwebui open-webui/open-webui -n openwebui
+```
+
+### PostgreSQL (CloudNativePG)
+Edit `k8s/openwebui/postgres.yaml` to change image version, then:
+```bash
+kubectl apply -f k8s/openwebui/postgres.yaml
+```
+
+### CloudNativePG Operator
+```bash
+helm upgrade cnpg-system cnpg/cloudnative-pg -n cnpg-system
+```
+
+## Monitoring
+
+### Check Cluster Health
+```bash
+# Cluster status
+kubectl get nodes
+
+# Pod status
+kubectl get pods -A
+
+# PVC status
+kubectl get pvc -A
+
+# CloudNativePG cluster
+kubectl get cluster -A
+```
+
+### View Logs
+```bash
+# OpenWebUI
+kubectl logs -n openwebui -l app.kubernetes.io/name=open-webui
+
+# PostgreSQL
+kubectl logs -n openwebui -l cnpg.io/cluster=openwebui-db
+
+# All OpenWebUI components
+kubectl logs -n openwebui --all-containers=true
+```
+
+## Secrets Management
+
+All secrets are stored in OpenBAO.
+
+```bash
+# Set Vault address
+export VAULT_ADDR=http://100.81.89.62:8200
+export VAULT_TOKEN=s.8sy7M9skEVO47Gsn12BtBjgO
+
+# List secrets
+vault kv list secret/pedro/
+
+# Get secret
+vault kv get secret/pedro/openwebui
+
+# Update secret
+vault kv put secret/pedro/openwebui KEY=value
+```
+
+## Common Tasks
+
+### Restart OpenWebUI
+```bash
+kubectl rollout restart deployment -n openwebui
+```
+
+### Connect to PostgreSQL
+```bash
+# Get password
+kubectl get secret openwebui-db-app -n openwebui -o jsonpath='{.data.password}' | base64 -d
+
+# Port forward
+kubectl port-forward -n openwebui svc/openwebui-db-rw 5432
+
+# Connect
+psql -h localhost -U postgres -d openwebui
+```
+
+### Scale PostgreSQL
+Edit `k8s/openwebui/postgres.yaml` to change `instances`, then:
+```bash
+kubectl apply -f k8s/openwebui/postgres.yaml
+```
+
+### Check Longhorn Volume Health
+```bash
+kubectl get volumes.longhorn.io -A
+```
+
+## Tailscale
+
+Tailscale provides external access to cluster services.
+
+```bash
+# Check tailscale-operator status
+kubectl get tailscale -A
+
+# View connected devices
+tailscale status
+```
+
+## Resource Limits
+
+| Component | CPU Limit | Memory Limit |
+|-----------|-----------|--------------|
+| openwebui-db | 500m | 512Mi |
+| open-webui | - | - |
+| Redis | - | - |
+
+## OpenWebUI Management
+
+### Architecture
+
+OpenWebUI runs in the `openwebui` namespace with the following components:
+- **openwebui-open-webui**: Main web UI (port 8080)
+- **openwebui-open-webui-redis**: WebSocket message broker
+- **openwebui-pipelines**: AI pipelines plugin
+- **openwebui-tika**: Document text extraction
+
+Database: CloudNativePG PostgreSQL cluster with pgvector in `openwebui` namespace.
+Storage: Longhorn volumes on Worker-1 2TB drive.
+
+### Deploy/Update OpenWebUI
+
+```bash
+# Update Helm values if needed
+vim helm/openwebui/values.yaml
+
+# Deploy/upgrade
+helm upgrade openwebui open-webui/open-webui -n openwebui -f helm/openwebui/values.yaml
+
+# Verify deployment
+kubectl get pods -n openwebui
+```
+
+### Update Database (PostgreSQL)
+
+Edit `k8s/openwebui/postgres.yaml` to change:
+- Image version (`spec.image`)
+- Instance count (`spec.instances`)
+- Resources/storage
+
+```bash
+kubectl apply -f k8s/openwebui/postgres.yaml
+
+# Verify cluster status
+kubectl get cluster -n openwebui
+```
+
+### Update Redis
+
+```bash
+# Redis is deployed via Helm chart sub-chart
+helm upgrade openwebui open-webui/open-webui -n openwebui -f helm/openwebui/values.yaml
+```
+
+### Connect to PostgreSQL
+
+```bash
+# Get password
+kubectl get secret openwebui-db-app -n openwebui -o jsonpath='{.data.password}' | base64 -d
+
+# Port forward to primary
+kubectl port-forward -n openwebui svc/openwebui-db-rw 5432
+
+# Connect (use password from above)
+psql -h localhost -U postgres -d openwebui
+```
+
+### Debug OpenWebUI
+
+```bash
+# Check pod status
+kubectl get pods -n openwebui
+
+# View logs
+kubectl logs -n openwebui deploy/openwebui-open-webui -c openwebui --tail=50
+
+# Check environment variables
+kubectl get deploy openwebui-open-webui -n openwebui -o jsonpath='{.spec.template.spec.containers[0].env}' | jq
+
+# Check for errors in all containers
+kubectl logs -n openwebui --all-containers=true --tail=100 | grep -i error
+```
+
+### Test Model Backend Connection
+
+The GPU inference runs on `100.121.229.114:8000` (pedrogpt.tail6fbc5.ts.net via Tailscale).
+
+```bash
+# From your local machine (with Tailscale)
+curl http://pedrogpt:8000/v1/models
+
+# From a pod in cluster
+kubectl run curl-test --image=curlimages/curl --restart=Never -n openwebui -- curl http://100.121.229.114:8000/v1/models
+
+# Check OpenWebUI can reach the backend (look for connection errors in logs)
+kubectl logs -n openwebui deploy/openwebui-open-webui | grep -i "connection\|error\|failed"
+```
+
+### Common Issues
+
+**"Server Connection Error" in OpenWebUI UI:**
+- Check that `OPENAI_API_BASE_URL` is set to IP address (not hostname): `http://100.121.229.114:8000/v1`
+- Verify model backend is running: `curl http://100.121.229.114:8000/v1/models`
+- Check pods can resolve DNS (may need to use IP instead of hostname)
+
+**Chats not saving:**
+- Verify PostgreSQL is running: `kubectl get cluster -n openwebui`
+- Check database connection in logs
+- Ensure VECTOR_DB=pgvector is set
+
+**WebSocket issues:**
+- Check Redis is running: `kubectl get pods -n openwebui | grep redis`
+- Verify `websocket.manager: redis` in values.yaml
+
+### Restart OpenWebUI
+
+```bash
+# Restart all deployments
+kubectl rollout restart deployment -n openwebui
+
+# Watch status
+kubectl rollout status deployment -n openwebui
+```
+
+## Troubleshooting
+
+See [troubleshooting.md](./troubleshooting.md) for common issues.

--- a/docs/vllm-cpu-embeddings.md
+++ b/docs/vllm-cpu-embeddings.md
@@ -1,0 +1,100 @@
+# vLLM CPU Embeddings Server
+
+This document describes the CPU-based embeddings server deployment using vLLM.
+
+## Overview
+
+The embeddings server runs as a Kubernetes Deployment in the pedro-bots helm chart, providing embeddings for the mempalace service. It uses the official vLLM CPU image from AWS ECR Public.
+
+**Reference**: [vLLM K8s CPU Deployment](https://docs.vllm.ai/en/stable/deployment/k8s/)
+
+## Docker Image
+
+```dockerfile
+FROM public.ecr.aws/q9t5s3a7/vllm-cpu-release-repo:latest
+
+RUN mkdir -p /models
+
+EXPOSE 8081
+
+CMD ["vllm", "serve", "nomic-ai/nomic-embed-text-v1.5", "--trust-remote-code", "--port", "8081"]
+```
+
+Build and push:
+```bash
+docker build -f cli/embeddings/Dockerfile -t 100.81.89.62:5000/pedro-embeddings:latest .
+podman push 100.81.89.62:5000/pedro-embeddings:latest
+```
+
+## Helm Configuration
+
+The embeddings deployment is defined in `charts/pedro-bots/templates/embeddings-deployment.yaml`:
+
+```yaml
+embeddings:
+  enabled: true
+  image:
+    repository: 100.81.89.62:5000/pedro-embeddings
+    tag: latest
+  model: "nomic-ai/nomic-embed-text-v1.5"
+  hfTokenSecret: "hf-token-secret"
+  resources:
+    limits:
+      cpu: "4"
+      memory: 8Gi
+    requests:
+      cpu: "2"
+      memory: 4Gi
+```
+
+## Required Secrets
+
+Create a Kubernetes Secret for Hugging Face access (for gated models):
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-token-secret
+type: Opaque
+stringData:
+  token: "REPLACE_WITH_HF_TOKEN"
+```
+
+## Deployment
+
+```bash
+helm upgrade --install pedro-bots charts/pedro-bots -n chatbot
+```
+
+## Testing
+
+```bash
+# Get the service endpoint
+kubectl get svc -n chatbot | grep embeddings
+
+# Test embeddings endpoint
+curl http://pedro-embeddings.chatbot.svc.cluster.local:8081/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{"model": "nomic-ai/nomic-embed-text-v1.5", "input": "Hello world"}'
+```
+
+## Mempalace Integration
+
+The mempalace deployment connects to embeddings via:
+
+```yaml
+env:
+  - name: EMBEDDING_LLM_PATH
+    value: "http://pedro-embeddings.chatbot.svc.cluster.local:8081"
+  - name: EMBEDDING_MODEL
+    value: "nomic-embed-text"
+```
+
+Note: The endpoint path does NOT include `/v1` because vLLM serves embeddings at `/v1/embeddings` directly.
+
+## Troubleshooting
+
+- **Startup time**: vLLM CPU takes ~60s to load the model. Probes are configured with `initialDelaySeconds: 60`
+- **Model download**: First deployment will download the model from Hugging Face (~500MB)
+- **Resource limits**: CPU embeddings are slow; adjust resources based on latency requirements

--- a/helm/openwebui/values.yaml
+++ b/helm/openwebui/values.yaml
@@ -1,0 +1,130 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/open-webui/open-webui
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8080
+
+# Database - Supabase with pgvector
+databaseUrl: ""
+
+# Redis - use existing
+redis:
+  enabled: false
+
+websocket:
+  enabled: true
+  manager: redis
+
+# Ollama - disabled, using external pedrogpt
+ollama:
+  enabled: false
+
+# Tika for document extraction
+tika:
+  enabled: true
+
+# Pipelines
+pipelines:
+  enabled: true
+  persistence:
+    enabled: false
+
+# Storage - SeaweedFS S3
+persistence:
+  enabled: true
+  provider: s3
+  s3:
+    bucket: openwebui
+    region: us-east-1
+    accessKeyExistingSecret: openwebui-secrets
+    accessKeyExistingAccessKey: AWS_ACCESS_KEY_ID
+    secretKeyExistingSecret: openwebui-secrets
+    secretKeyExistingSecretKey: AWS_SECRET_ACCESS_KEY
+    endpointUrl: "http://seaweedfs-s3:8332"
+
+# OpenWebUI configuration
+extraEnvVars:
+  - name: WEBUI_SECRET_KEY
+    valueFrom:
+      secretKeyRef:
+        name: openwebui-secrets
+        key: WEBUI_SECRET_KEY
+  - name: OPENAI_API_BASE_URL
+    value: "http://100.121.229.114:8000/v1"
+  - name: OPENAI_API_KEY
+    value: "stub-key-for-local-ollama"
+  - name: VECTOR_DB
+    value: "pgvector"
+  - name: PGVECTOR_DB_URL
+    valueFrom:
+      secretKeyRef:
+        name: openwebui-secrets
+        key: DATABASE_URL
+        optional: true
+  - name: ENABLE_DB_MIGRATIONS
+    value: "true"
+  - name: DEFAULT_LOCALE
+    value: "en"
+  - name: WEBUI_URL
+    value: "http://ai.tail6fbc5.ts.net"
+  - name: WEBUI_NAME
+    value: "PedroGPT UI"
+  - name: ENABLE_TOOL_WEBSEARCH
+    value: "true"
+  - name: WEBSEARCH_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: openwebui-secrets
+        key: WEBSEARCH_API_KEY
+        optional: true
+  - name: WEBSEARCH_ENGINE
+    value: "ddg"
+  - name: ENABLE_AUDIO_TTS
+    value: "true"
+  - name: ENABLE_AUDIO_WHISPER
+    value: "true"
+  - name: WHISPER_API_URL
+    value: "http://whisper:9000"
+  - name: RAG_EMBEDDING_ENGINE
+    value: "openai"
+  - name: RAG_EMBEDDING_MODEL
+    value: "text-embedding-3-small"
+  - name: ENABLE_SIGNUP
+    value: "false"
+  - name: ENABLE_PGvector
+    value: "false"
+  - name: OLLAMA_BASE_URLS
+    value: ""
+  - name: ENABLE_OLLAMA_API
+    value: "false"
+
+# No ingress - we'll use Tailscale
+ingress:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1000m
+    memory: 2Gi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: 8080
+  initialDelaySeconds: 60
+  periodSeconds: 30
+
+readinessProbe:
+  httpGet:
+    path: /
+    port: 8080
+  initialDelaySeconds: 30
+  periodSeconds: 10

--- a/k8s/openwebui/postgres.yaml
+++ b/k8s/openwebui/postgres.yaml
@@ -1,0 +1,29 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: openwebui-db
+  namespace: openwebui
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.4
+  enableSuperuserAccess: true
+
+  storage:
+    storageClass: longhorn
+    size: 10Gi
+
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 256Mi
+
+  bootstrap:
+    initdb:
+      database: openwebui
+      owner: postgres
+      postInitSQL:
+        - CREATE EXTENSION IF NOT EXISTS vector;
+        - ALTER USER postgres WITH PASSWORD 'PMy8GF6KuomeWdqYef6FE0F6pKgrVb8vw9jcQrJwBfkiWZD0f5LygsRhdEuNf7lB';

--- a/k8s/tailscale/connector.yaml
+++ b/k8s/tailscale/connector.yaml
@@ -4,7 +4,6 @@ metadata:
   name: gpu-inference-connector
   namespace: tailscale
 spec:
-  # Tag this connector with the pedro-ops tag
   tags:
     - tag:k8s-pedro-ops
 

--- a/k8s/tailscale/openwebui-ingress.yaml
+++ b/k8s/tailscale/openwebui-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openwebui-tailscale
+  namespace: openwebui
+  annotations:
+    tailscale.com/tailnet-fqdn: ai.tail6fbc5.ts.net
+    tailscale.com/tags: tag:k8s-pedro-ops,tag:production
+spec:
+  ingressClassName: tailscale
+  defaultBackend:
+    service:
+      name: openwebui-open-webui
+      port:
+        number: 8080
+  tls:
+    - hosts:
+        - ai.tail6fbc5.ts.net

--- a/scripts/backup-openwebui-pg.sh
+++ b/scripts/backup-openwebui-pg.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+NAMESPACE="openwebui"
+CLUSTER_NAME="openwebui-db"
+BACKUP_NAME="openwebui-backup-$(date +%Y%m%d-%H%M%S)"
+TIMEOUT=300
+
+echo "Creating Longhorn snapshot backup for ${CLUSTER_NAME}..."
+
+for pvc in $(kubectl get pvc -n ${NAMESPACE} -l cnpg.io/cluster=${CLUSTER_NAME} -o jsonpath='{.items[*].metadata.name}'); do
+    echo "Creating snapshot for PVC: ${pvc}"
+    cat <<EOF | kubectl apply -f -
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: ${BACKUP_NAME}-${pvc}
+  namespace: ${NAMESPACE}
+spec:
+  volumeSnapshotClassName: longhorn
+  source:
+    persistentVolumeClaimName: ${pvc}
+EOF
+done
+
+echo "Backup initiated: ${BACKUP_NAME}"
+echo "PVCs backed up: $(kubectl get pvc -n ${NAMESPACE} -l cnpg.io/cluster=${CLUSTER_NAME} -o jsonpath='{.items[*].metadata.name}')"
+echo ""
+echo "To list snapshots:"
+echo "  kubectl get volumesnapshot -n ${NAMESPACE}"
+echo ""
+echo "To restore from backup:"
+echo "  kubectl apply -f - <<EOF"
+echo "  apiVersion: v1"
+echo "  kind: PersistentVolumeClaim"
+echo "  metadata:"
+echo "    name: <new-pvc-name>"
+echo "    namespace: ${NAMESPACE}"
+echo "  spec:"
+echo "    dataSource:"
+echo "      name: ${BACKUP_NAME}-<pvc-name>"
+echo "      kind: VolumeSnapshot"
+echo "      apiGroup: snapshot.storage.k8s.io"
+echo "    storageClassName: longhorn"
+echo "    accessModes:"
+echo "      - ReadWriteOnce"
+echo "    resources:"
+echo "      requests:"
+echo "        storage: 10Gi"
+echo "EOF"


### PR DESCRIPTION
Deploy OpenWebUI with CloudNativePG PostgreSQL (pgvector) on Longhorn, using external llama.cpp GPU inference at 100.121.229.114:8000, Tailscale ingress at ai.tail6fbc5.ts.net, SeaweedFS for file storage, and add maintenance docs for updating/debugging OpenWebUI.