### PR TITLE
fix: deploy OpenWebUI, fix latent chart bugs, automate for rebuilds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ foundry logs
 
 ```bash
 # Set kubeconfig
-export KUBECONFIG=~/.kube/pedro-ops-config
+export KUBECONFIG=~/.foundry/kubeconfig
 
 # Cluster operations
 kubectl get nodes

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ export TS_CLIENT_SECRET="your_client_secret"
 ./scripts/phase4-install-tailscale.sh
 
 # Configure kubectl access
-export KUBECONFIG=~/.kube/pedro-ops-config
+export KUBECONFIG=~/.foundry/kubeconfig
 kubectl get nodes
 ```
 
@@ -123,7 +123,7 @@ pedro-ops/
 
 ```bash
 # Set kubeconfig
-export KUBECONFIG=~/.kube/pedro-ops-config
+export KUBECONFIG=~/.foundry/kubeconfig
 
 # View nodes
 kubectl get nodes -o wide

--- a/docker/moonshine-stt/Dockerfile
+++ b/docker/moonshine-stt/Dockerfile
@@ -1,0 +1,50 @@
+# Moonshine v2 speech-to-text, exposed over the OpenAI audio API.
+#
+# CPU-only by design: the cluster has no GPU nodes. Moonshine runs on
+# onnxruntime, so this needs no CUDA layer.
+FROM python:3.12-slim-bookworm
+
+# ffmpeg: transcodes whatever the browser records (webm/ogg) to 16 kHz mono.
+# libportaudio2: moonshine-voice depends on sounddevice, which dlopens
+#   PortAudio at import time even though this server never touches a mic.
+#   Without it the import fails outright.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        libportaudio2 \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG MOONSHINE_MODEL=small-streaming
+ARG MOONSHINE_LANGUAGE=en
+ENV MOONSHINE_MODEL=${MOONSHINE_MODEL} \
+    MOONSHINE_LANGUAGE=${MOONSHINE_LANGUAGE} \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Non-root, and the model cache must live somewhere that user owns.
+RUN useradd --create-home --uid 10001 moonshine
+ENV XDG_CACHE_HOME=/home/moonshine/.cache
+
+# Bake the weights into the image so pods never fetch from the network at
+# startup -- a cold pull would blow past the readiness probe and makes the
+# deployment dependent on an external host being up.
+RUN mkdir -p /home/moonshine/.cache && chown -R moonshine:moonshine /home/moonshine
+USER moonshine
+RUN python -c "\
+from moonshine_voice import get_model_for_language, string_to_model_arch; \
+import os; \
+name, arch = get_model_for_language(os.environ['MOONSHINE_LANGUAGE'], string_to_model_arch(os.environ['MOONSHINE_MODEL'])); \
+print('baked model:', name, arch)"
+
+COPY --chown=moonshine:moonshine app.py .
+
+EXPOSE 8000
+
+# Single worker on purpose: inference is serialised behind an asyncio lock
+# because Moonshine is not proven thread-safe. Scale with replicas.
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/docker/moonshine-stt/app.py
+++ b/docker/moonshine-stt/app.py
@@ -1,0 +1,207 @@
+"""OpenAI-compatible speech-to-text server backed by Moonshine v2.
+
+Open WebUI speaks the OpenAI audio API; Moonshine ships no server of its own,
+so this is the thin adapter between them.
+
+Design notes:
+  - The model is loaded once at startup, never per request. /healthz stays 503
+    until that finishes so Kubernetes does not route traffic to a cold pod.
+  - Moonshine's Transcriber is not documented as thread-safe, so every
+    inference is serialised behind an asyncio lock. Scale with replicas, not
+    threads (the deployment runs a single uvicorn worker).
+  - Anything the OpenAI spec allows but Moonshine cannot honour (temperature,
+    prompt, timestamp granularities) is accepted and ignored rather than
+    rejected -- clients send these routinely and erroring would break them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Optional
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse
+
+logging.basicConfig(
+    level=os.environ.get("LOG_LEVEL", "INFO").upper(),
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+log = logging.getLogger("moonshine-stt")
+
+MODEL_NAME = os.environ.get("MOONSHINE_MODEL", "small-streaming")
+LANGUAGE = os.environ.get("MOONSHINE_LANGUAGE", "en")
+TARGET_SAMPLE_RATE = 16_000
+# Guard against a huge upload exhausting pod memory during transcode.
+MAX_UPLOAD_BYTES = int(os.environ.get("MAX_UPLOAD_BYTES", 100 * 1024 * 1024))
+
+app = FastAPI(title="Moonshine STT", version="1.0.0")
+
+_transcriber = None
+_model_ready = False
+_model_error: Optional[str] = None
+_infer_lock = asyncio.Lock()
+
+
+def _load_model() -> None:
+    """Load Moonshine once. Called from the startup hook."""
+    global _transcriber, _model_ready, _model_error
+    try:
+        from moonshine_voice import (
+            ModelArch,
+            Transcriber,
+            get_model_for_language,
+            string_to_model_arch,
+        )
+
+        started = time.time()
+        try:
+            arch = string_to_model_arch(MODEL_NAME)
+        except Exception:
+            log.warning("unknown MOONSHINE_MODEL %r, falling back to small-streaming", MODEL_NAME)
+            arch = ModelArch.SMALL_STREAMING
+
+        # Returns a local path; weights are baked into the image at build time
+        # so this must not reach the network at runtime.
+        model_path, resolved_arch = get_model_for_language(LANGUAGE, arch)
+        transcriber = Transcriber(model_path=model_path, model_arch=resolved_arch)
+        transcriber.start()
+
+        _transcriber = transcriber
+        _model_ready = True
+        log.info(
+            "model ready name=%s lang=%s load_seconds=%.2f",
+            MODEL_NAME, LANGUAGE, time.time() - started,
+        )
+    except Exception as exc:  # noqa: BLE001 - surfaced via /healthz
+        _model_error = str(exc)
+        log.exception("model failed to load")
+
+
+@app.on_event("startup")
+async def startup() -> None:
+    # Load off the event loop so the health endpoint can answer while we wait.
+    await asyncio.get_running_loop().run_in_executor(None, _load_model)
+
+
+@app.on_event("shutdown")
+async def shutdown() -> None:
+    if _transcriber is not None:
+        try:
+            _transcriber.stop()
+            _transcriber.close()
+        except Exception:  # noqa: BLE001 - best effort on the way down
+            log.warning("transcriber shutdown was not clean", exc_info=True)
+
+
+@app.get("/healthz")
+async def healthz():
+    """200 only once the model is loaded and usable."""
+    if _model_ready:
+        return {"status": "ok", "model": MODEL_NAME, "language": LANGUAGE}
+    return JSONResponse(
+        status_code=503,
+        content={"status": "loading" if _model_error is None else "error",
+                 "error": _model_error},
+    )
+
+
+@app.get("/v1/models")
+async def list_models():
+    """Some OpenAI clients probe this before transcribing."""
+    return {"object": "list", "data": [{"id": MODEL_NAME, "object": "model", "owned_by": "moonshine"}]}
+
+
+def _decode_to_pcm16k(raw: bytes, suffix: str) -> tuple[list[float], int]:
+    """Transcode arbitrary container/codec input to 16 kHz mono float samples.
+
+    Open WebUI's mic records webm/ogg, and users upload mp3/m4a, so everything
+    goes through ffmpeg rather than trusting the input to already be wav.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        src = Path(tmp) / f"in{suffix or '.bin'}"
+        dst = Path(tmp) / "out.wav"
+        src.write_bytes(raw)
+
+        proc = subprocess.run(
+            [
+                "ffmpeg", "-nostdin", "-loglevel", "error", "-y",
+                "-i", str(src),
+                "-ar", str(TARGET_SAMPLE_RATE), "-ac", "1",
+                "-c:a", "pcm_s16le", str(dst),
+            ],
+            capture_output=True,
+        )
+        if proc.returncode != 0 or not dst.exists():
+            detail = proc.stderr.decode("utf-8", "replace")[:500] or "ffmpeg failed"
+            raise HTTPException(status_code=400, detail=f"could not decode audio: {detail}")
+
+        from moonshine_voice import load_wav_file
+
+        return load_wav_file(dst)
+
+
+def _run_inference(audio: list[float], sample_rate: int) -> str:
+    result = _transcriber.transcribe_without_streaming(audio, sample_rate)
+    # Transcript.text carries "[0.00s] " timestamp prefixes; join the line
+    # texts instead so callers get clean prose.
+    lines = getattr(result, "lines", None)
+    if lines:
+        return " ".join(line.text.strip() for line in lines if line.text).strip()
+    return str(getattr(result, "text", "")).strip()
+
+
+@app.post("/v1/audio/transcriptions")
+async def transcribe(
+    file: UploadFile = File(...),
+    model: Optional[str] = Form(None),
+    language: Optional[str] = Form(None),
+    response_format: Optional[str] = Form("json"),
+    # Accepted for OpenAI compatibility, ignored by Moonshine.
+    prompt: Optional[str] = Form(None),
+    temperature: Optional[str] = Form(None),
+    timestamp_granularities: Optional[str] = Form(None),
+):
+    if not _model_ready:
+        raise HTTPException(status_code=503, detail=f"model not ready: {_model_error or 'loading'}")
+
+    raw = await file.read()
+    if not raw:
+        raise HTTPException(status_code=400, detail="empty audio file")
+    if len(raw) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail=f"audio exceeds {MAX_UPLOAD_BYTES} bytes")
+
+    if language and language.lower() not in (LANGUAGE, "auto", ""):
+        # Honouring this would need a different model; log rather than fail.
+        log.info("ignoring requested language=%r, server serves %r", language, LANGUAGE)
+
+    suffix = Path(file.filename or "").suffix.lower()
+    loop = asyncio.get_running_loop()
+    audio, sample_rate = await loop.run_in_executor(None, _decode_to_pcm16k, raw, suffix)
+
+    duration = len(audio) / sample_rate if sample_rate else 0.0
+    started = time.time()
+    # Serialised: Moonshine inference is not proven thread-safe.
+    async with _infer_lock:
+        text = await loop.run_in_executor(None, _run_inference, audio, sample_rate)
+    elapsed = time.time() - started
+
+    log.info(
+        "transcribed bytes=%d audio_seconds=%.2f infer_seconds=%.2f rtf=%.3f",
+        len(raw), duration, elapsed, (elapsed / duration) if duration else 0.0,
+    )
+
+    if (response_format or "json").lower() == "text":
+        return PlainTextResponse(text)
+    return {"text": text}
+
+
+@app.get("/")
+async def root():
+    return {"service": "moonshine-stt", "model": MODEL_NAME, "ready": _model_ready}

--- a/docker/moonshine-stt/requirements.txt
+++ b/docker/moonshine-stt/requirements.txt
@@ -1,0 +1,6 @@
+# Pinned deliberately: this image is rebuilt rarely and must be reproducible.
+# Bump intentionally, then re-run the smoke test in RUNBOOK.md.
+moonshine-voice==0.1.0
+fastapi==0.141.1
+uvicorn==0.52.1
+python-multipart==0.0.32

--- a/docs/cluster-audit-2026-08-03.md
+++ b/docs/cluster-audit-2026-08-03.md
@@ -121,7 +121,34 @@ InternalError: We encountered an internal error, please try again. status code: 
 Purge the stale filer metadata (or recreate the `loki`/`velero` buckets) so the filer matches the
 empty volume store. Loki will not start until this is resolved.
 
-### 1.5 OpenBAO: keys survived, data did not — and it was never in-cluster
+### 1.5 OpenBAO — CORRECTED: alive and healthy on 100.70.90.12
+
+> **CORRECTION (same day).** The original finding below said OpenBAO's data was destroyed.
+> **That was wrong.** OpenBAO is a *host-level* Foundry component (`foundry component list`
+> shows it with no dependencies, like Zot) and it **survived the rebuild** on the old host:
+>
+> ```
+> $ curl http://100.70.90.12:8200/v1/sys/health
+> {"initialized": true, "sealed": false, "version": "2.0.0", ...}
+> $ foundry component status openbao
+> Healthy: true   Message: healthy (initialized, unsealed)
+> ```
+>
+> The stored root token at `~/.foundry/openbao-keys/test/keys.json` authenticates
+> successfully, and the `foundry-core/` KV mount is intact.
+>
+> The error was inferring destruction from the absent PVC — but OpenBAO never had a PVC,
+> because it never ran in Kubernetes. Only the *injector* is in-cluster, and it points at
+> `externalVaultAddr: http://100.70.90.12:8200`, which is correct and reachable.
+>
+> **What is still true:** only the injector is deployed in-cluster, `100.81.89.62:8200` is
+> dead (that host is gone), and no in-cluster workload can currently use injection until the
+> injector's config is confirmed against the surviving server.
+
+<details>
+<summary>Original (incorrect) finding, kept for the record</summary>
+
+#### OpenBAO: keys survived, data did not — and it was never in-cluster
 
 The assumption that OpenBAO is intact does not hold, though the conclusion is better than feared.
 
@@ -147,6 +174,12 @@ entirely new share set.
 **The real recovery path is 1Password**, which is the documented source of truth. This is
 re-initialize-and-repopulate, not unseal-and-recover. Archive the old `keys.json` before anything
 overwrites it.
+
+</details>
+
+**Do not act on the collapsed section above** — no re-initialization is needed. OpenBAO is
+healthy and holds its existing data. Use `scripts/sync-openwebui-secrets-to-openbao.sh` to push
+cluster secrets into it.
 
 ---
 

--- a/docs/cluster-audit-2026-08-03.md
+++ b/docs/cluster-audit-2026-08-03.md
@@ -1,0 +1,337 @@
+# Cluster Audit — 2026-08-03
+
+Post-rebuild audit of the K3s cluster at `~/.foundry/kubeconfig`, covering drift vs. this repo,
+backups, networking, secrets setup, and the redeploy worklist.
+
+**Scope note:** read-only. No cluster mutations, no repo changes beyond this document.
+
+---
+
+## 0. The cluster is not the one this repo documents
+
+The cluster was rebuilt ~4h before this audit. Node identity changed completely:
+
+| | Documented (CLAUDE.md, README, architecture.md) | Actual |
+|---|---|---|
+| Control plane | 100.81.89.62 | **blue1 192.168.1.185** |
+| Worker 1 | 100.70.90.12 | **blue2 192.168.1.97** |
+| Worker 2 | 100.125.196.1 | **refurb 192.168.1.253** |
+| VIP | 100.81.89.100 | **10.0.0.11** (unroutable from the LAN) |
+| K3s | v1.28.x | **v1.36.2+k3s1** |
+
+The cluster is now on the plain LAN (192.168.1.0/24). Tailscale is **entirely absent** —
+no operator, no CRDs, no namespace, no ingressclass. Pod CIDR 10.42.0.0/16 and service
+CIDR 10.43.0.0/16 do not conflict with the LAN.
+
+**A redeploy was already in progress and stalled** before this audit finished: helm releases
+`pedro` (ns `chatbot`) and `openbao-injector` (ns `openbao`) were installed at 14:56–14:57,
+and the `redditwatch` namespace appeared minutes earlier. All are failing.
+
+---
+
+## 1. Critical findings
+
+### 1.1 There is no backup, and nothing to restore from
+
+`kubectl -n velero get backups` returns **no resources**. The `velero` S3 bucket is empty.
+No Longhorn `backupvolumes` exist. **No recovery point exists for this cluster or its predecessor.**
+
+Worse, the nightly schedule that does exist would not capture data even once it runs:
+
+- `deployNodeAgent: false` → no node-agent DaemonSet → **kopia filesystem backup cannot run**
+- CSI snapshot CRDs (`volumesnapshots.snapshot.storage.k8s.io`) are **not installed**
+- Longhorn `backuptargets/default` has an **empty URL**, `available: false`; zero recurring jobs
+
+The failure mode is the dangerous kind: the backup will report `Completed` while containing
+**Kubernetes API objects only and zero volume data**.
+
+Additionally, the backup destination (SeaweedFS) is a 50Gi Longhorn PVC **inside the same
+cluster**, with all four SeaweedFS pods on `refurb`. There is no off-cluster copy of anything.
+Losing `refurb` loses the primary data and the backup destination simultaneously.
+
+**This is the highest-priority item in this document.**
+
+### 1.2 Zot registry is up but empty — the hard blocker on redeploy
+
+```
+$ curl http://100.81.89.62:5000/v2/_catalog   →  {"repositories":[]}
+$ curl http://192.168.1.185:5000/v2/_catalog  →  {"repositories":[]}
+```
+
+Zot is reachable on **both** the Tailscale and LAN addresses, so this is *not* a connectivity
+problem. The registry's **storage did not survive the rebuild**. Every private image is gone.
+
+Consequently every private-registry workload is in `ImagePullBackOff`:
+
+| Namespace | Workload | Image |
+|---|---|---|
+| chatbot | pedro-twitch | `100.81.89.62:5000/pedro-twitch:fix-lo-db` |
+| chatbot | pedro-keepalive | `100.81.89.62:5000/pedro-keepalive:df12033` |
+| chatbot | pedro-mempalace | blocked — missing ServiceAccount |
+| redditwatch | cfp-manual + 4 cronjobs | `100.81.89.62:5000/redditwatch:latest` |
+
+**No amount of re-running Helm fixes this.** Images must be rebuilt and re-pushed first.
+
+Secondary, unverified: pull errors read `Head "https://100.81.89.62:5000/..."` while Zot serves
+plain HTTP, suggesting `/etc/rancher/k3s/registries.yaml` was lost in the rebuild. Could not be
+confirmed — SSH to all three nodes was refused (publickey). **Verify this on the nodes yourself**,
+or pushing images will not be sufficient.
+
+### 1.3 There is no working ingress path into the cluster
+
+`contour-envoy` is `type: ClusterIP` with a hardcoded `spec.externalIPs: [10.0.0.11]` and an
+empty `status.loadBalancer`. There are **zero LoadBalancer services cluster-wide**. Envoy uses
+no `hostNetwork`/`hostPort`, so no node binds :80/:443.
+
+- `ping 10.0.0.11` → 100% loss (VIP is on `enp1s0`, off-LAN and unroutable)
+- `curl http://192.168.1.185/` → connection refused
+
+Every ingress has a blank ADDRESS. Grafana, Prometheus, Longhorn UI, and SeaweedFS are reachable
+only via `kubectl port-forward`.
+
+**And no TLS exists.** cert-manager is not installed despite `foundry/stack.yaml:30` declaring it
+enabled. All five ingresses reference `*-tls` secrets that will never be created:
+
+```
+level=error msg="unresolved secret reference" secret=monitoring/grafana-tls
+level=error msg="error identifying listener" error="no HTTPS listener configured"
+```
+
+> **Fix cert-manager BEFORE restoring the LB IP.** Otherwise Longhorn UI and the SeaweedFS S3
+> endpoint — both unauthenticated admin surfaces — land on the LAN in cleartext.
+
+### 1.4 SeaweedFS is split-brained — root cause of the Loki crashloop
+
+The filer's metadata survived the rebuild; the volume server's data did not.
+
+```
+$ curl seaweedfs-master:9333/dir/status  →  "Volumes":0, "VolumeIds":" "
+$ kubectl -n seaweedfs logs seaweedfs-s3-...
+  volume 12 not found for fileId 12,41a35b10aca4
+```
+
+Every S3 GET for a pre-rebuild object returns HTTP 500. That is precisely why `loki-0` is in
+`CrashLoopBackOff` (13 restarts):
+
+```
+init compactor: failed to init delete store: failed to get s3 object:
+InternalError: We encountered an internal error, please try again. status code: 500
+```
+
+Purge the stale filer metadata (or recreate the `loki`/`velero` buckets) so the filer matches the
+empty volume store. Loki will not start until this is resolved.
+
+### 1.5 OpenBAO: keys survived, data did not — and it was never in-cluster
+
+The assumption that OpenBAO is intact does not hold, though the conclusion is better than feared.
+
+Evidence it is gone:
+- No `openbao` PVC; only 5 PVCs exist cluster-wide
+- All 5 PVs are `Bound` with reclaim policy **`Delete`** — no `Released`/`Retained` volume to re-bind
+- No Longhorn backup, no Velero backup
+
+The helm values reveal it was **never an in-cluster server**:
+
+```yaml
+server:   {enabled: false}
+injector: {enabled: true, externalVaultAddr: "http://100.70.90.12:8200"}   # OLD cluster IP
+```
+
+`http://100.81.89.62:8200` is **dead**. Only the injector deployed, and it has no server to talk to.
+
+**What survived:** `~/.foundry/openbao-keys/test/keys.json` (0600) holds `root_token`, 5 unseal
+shares, threshold 3. **These do not help.** Unseal shares decrypt a storage backend that no longer
+exists; a fresh OpenBAO comes up *uninitialized*, not sealed, and `bao operator init` mints an
+entirely new share set.
+
+**The real recovery path is 1Password**, which is the documented source of truth. This is
+re-initialize-and-repopulate, not unseal-and-recover. Archive the old `keys.json` before anything
+overwrites it.
+
+---
+
+## 2. Storage — degraded and mis-documented
+
+The 2TB drive is on **`refurb`**, not "Worker-1/blue2" as CLAUDE.md claims. It is the only bulk disk:
+
+| Node | Disk | Capacity | Available |
+|---|---|---|---|
+| blue1 | default | 105 GB | 66 GB |
+| blue2 | default | 105 GB | 74.8 GB |
+| refurb | **data-disk-001** | **1622 GB** | 1311 GB |
+| refurb | default | 105 GB | 34.4 GB |
+
+Two volumes are permanently `degraded` with a single replica:
+
+```
+pvc-140c186f (prometheus 200Gi): ReplicaSchedulingFailure — "insufficient storage"
+pvc-a5650a54 (loki 10Gi):        degraded, 1 running, 2 stopped
+```
+
+This is arithmetic, not misconfiguration: a 200Gi replica **cannot fit** on the 105GB nodes, and
+`replica-soft-anti-affinity: false` requires distinct nodes. With `numberOfReplicas: 3`, replicas
+2 and 3 are unschedulable forever. Either add bulk disks to blue1/blue2, shrink Prometheus
+retention, or set `numberOfReplicas: 1` and document the volumes as single-copy.
+
+**Dual-default StorageClass bug** — both are marked default:
+
+```
+local-path (default)   rancher.io/local-path
+longhorn   (default)   driver.longhorn.io
+```
+
+Any PVC without an explicit `storageClassName` binds nondeterministically. **Fix before deploying
+apps**, or workloads will land on non-replicated local-path storage by chance.
+
+---
+
+## 3. Services and redeploy worklist
+
+### Currently running (infrastructure only)
+k3s · contour+envoy · longhorn · kube-prometheus-stack · grafana · alertmanager · promtail ·
+seaweedfs · velero · external-dns · kube-vip · coredns
+
+### Missing — the redeploy list, in dependency order
+
+| # | Component | Source | Blocked by |
+|---|---|---|---|
+| 0 | **Rebuild + push all Zot images** | build hosts | — **do this first** |
+| 1 | **cert-manager** | `foundry/stack.yaml:30` (declared, not installed) | — |
+| 2 | **SeaweedFS metadata purge** | — | unblocks Loki + Velero |
+| 3 | **OpenBAO server + init + repopulate from 1Password** | `foundry component install openbao` | — |
+| 4 | **Tailscale operator** (if being kept) | `scripts/phase4-install-tailscale.sh` | TS OAuth creds |
+| 5 | **CNPG operator** | undeclared prerequisite | — |
+| 6 | pedro-bots / **iam_pedro** | `~/code/pedro/iam_pedro/charts/pedro-bots` | #0, #3, llama.cpp |
+| 7 | pedro-embed-server | `helm/pedro-embed-server/` | — (public image) |
+| 8 | OpenWebUI + Postgres | `helm/openwebui/`, `k8s/openwebui/postgres.yaml` | #5, #2 |
+| 9 | redditwatch / pedro-agents | `~/code/pedro/pedro-bots/charts/pedro-agents` | #0 |
+| 10 | Tailscale ingresses | `k8s/tailscale/`, `helm/tailscale-ingresses/` | #4 |
+
+### iam_pedro — located
+
+**Not in this repo.** It is a separate Go repo at **`~/code/pedro/iam_pedro`** (Twitch/Discord LLM
+bot: llama.cpp + langchain-go + Supabase).
+
+- Chart: `~/code/pedro/iam_pedro/charts/pedro-bots`, release **`pedro`**, namespace **`chatbot`**
+- Components: `pedro-twitch`, `pedro-discord`, `pedro-keepalive`, `pedro-mempalace`
+- **Already installed** (rev 1, 14:56) and failing on the empty registry
+- Deploy docs: `~/code/pedro/iam_pedro/deployment/README.md`
+
+Do not confuse it with the sibling `~/code/pedro/pedro-bots` — a *different* (Python/Reddit) repo
+that feeds the `redditwatch` namespace.
+
+### External dependencies
+
+| Target | Status |
+|---|---|
+| pedrogpt vLLM `100.121.229.114:8000` | **UP** (HTTP 200) |
+| pedrogpt llama.cpp `100.121.229.114:8080` | **DOWN** — all pedro-bots point here |
+| Zot `100.81.89.62:5000` | up, **catalog empty** |
+| OpenBAO `100.81.89.62:8200` | **DOWN** |
+| PowerDNS `100.81.89.62:8081` | up (401), external to cluster, unmanaged |
+
+### Known config bugs to fix while redeploying
+
+- `k8s/monitoring/grafana-values.yaml:44` — Loki datasource points at
+  `loki-gateway.monitoring.svc` but Loki now lives in ns `loki`. **Dangling datasource.**
+- `helm/openwebui/values.yaml:48` — SeaweedFS port `8332`; the live service port is **8333**.
+- pedro-bots expects embeddings at `pedro-embeddings.chatbot:8081`, but the chart names the
+  service `pedro-embed-server`. **Name mismatch** — set `fullnameOverride` or fix the env var.
+- `chatbot/pedro-mempalace` — `serviceaccount "pedro-mempalace" not found`.
+- `scripts/k8s/k3s-config-blue1.yaml:9` hardcodes `node-ip: 192.168.1.128`; blue1 is **.185**.
+  `scripts/k8s/coredns-configmap.yaml:31-32` has the same stale IPs. **Running
+  `scripts/k8s/apply-cluster-config.sh` as-is would break the cluster.**
+- `scripts/backup-openwebui-pg.sh` cannot run — it creates `VolumeSnapshot` resources whose CRDs
+  are not installed. `docs/maintenance.md:23-56` documents this non-functional path as *the*
+  Postgres backup procedure.
+
+---
+
+## 4. Secrets — how they are actually wired
+
+Three inconsistent patterns coexist:
+
+**A. OpenBAO injector annotations — inert.** Pods in `chatbot`/`redditwatch` carry
+`vault.hashicorp.com/agent-inject` annotations, but no injector webhook exists
+(`mutatingwebhookconfigurations` shows only prometheus + longhorn). No `vault-agent` sidecar is
+ever created. Fails silently as an app-level auth error much later.
+
+**B. Plain K8s Secrets via `envFrom`/`secretKeyRef` — what actually works today.**
+`chatbot/pedro-secrets` (5 keys), `redditwatch/redditwatch-secrets` (9 keys). These are created
+out-of-band: **no script in the repo creates them.** `docs/architecture.md:295` references
+`scripts/create-secrets-from-openbao.sh`, which **does not exist**. The OpenBAO → K8s Secret leg
+of the documented pipeline is unimplemented — which is why these cannot be reproduced after a rebuild.
+
+**C. Foundry vars** — `~/.foundryvars` via `scripts/setup-tailscale-secrets.sh`.
+
+Not used anywhere: External Secrets Operator, Sealed Secrets, SOPS, age.
+
+### Security issues
+
+- **PowerDNS API key is a plaintext container arg** on the live external-dns deployment
+  (`--pdns-api-key=797c637e...`), readable by anyone with pod-get, sent over plain HTTP to a
+  still-live server. `foundry/stack.yaml:21` uses `${secret:dns:api_key}` correctly; the deployed
+  manifest does not honor it. **Rotate it.**
+- **`~/.foundry/stack.yaml` holds plaintext S3 credentials** in ~5 places, one key pair reused
+  across Loki, SeaweedFS, and Velero — so Loki's credentials can delete every Velero backup.
+  Outside the repo, so not a git leak, but unencrypted on disk. Rotate and split.
+- **`k8s/openwebui/postgres.yaml:29` commits a plaintext Postgres superuser password to git.**
+  Violates the CLAUDE.md "never commit secrets" rule.
+- A live GitHub OAuth client ID is in the **uncommitted** `docs/secrets-playbook.md:250` diff.
+  Low severity (client IDs are semi-public) but placeholder it before committing.
+- `keys.json` holds all 5 unseal shares **and** the root token in one file — a single-file
+  compromise is a full vault compromise, defeating the purpose of Shamir splitting.
+
+**History is clean:** `git log --all -- secrets/` shows only `README.md` and
+`secrets-map.yaml.example` were ever committed. No real secret is in git history.
+
+---
+
+## 5. Stale documentation
+
+`docs/cluster-state.md` is the newest commit yet entirely wrong: it lists 17 namespaces
+(including `tailscale`, `openbao`, `openwebui`, `kei`, `pedro`, `pedrotag`, `cnpg-system` — none
+exist) against an actual 13, and swaps the blue2/refurb IPs.
+
+Wrong node IPs/VIP: `CLAUDE.md:31-34`, `README.md:26-30`, `docs/architecture.md:31-33,48-50`,
+`docs/cluster-state.md:11-13`, `docs/tailscale-setup.md:60,67-68`, `docs/troubleshooting.md`
+(~13 `ssh root@100.x` commands).
+
+Claims contradicted by reality:
+- `CLAUDE.md:44` — PowerDNS serves `soypetetech.local` → **NXDOMAIN**, no stub in the Corefile
+- `CLAUDE.md:45-46` — Tailscale operator + split DNS → neither exists
+- `CLAUDE.md:39-42` — 2TB drive on Worker-1 at `/data/persistent-storage` → it is on `refurb`,
+  and Longhorn uses `/var/lib/longhorn`
+- `CLAUDE.md:40` — "2 replicas" → configured for 3
+- `CLAUDE.md:97-99`, `README.md:96-99` — `kubectl apply -k k8s/base` / `k8s/overlays/production`
+  → **neither directory exists**; there are no `kustomization.yaml` files anywhere despite
+  `CLAUDE.md:117` mandating Kustomize
+- `CLAUDE.md:218-221` — references `docs/tailscale-integration.md`, which **does not exist**
+- `README.md:240-246` + `k8s/monitoring/README.md:136` — `scripts/backup-cluster.sh` and bucket
+  `s3://pedro-ops-backups/` → **neither exists**
+- `README.md:38,41` — Loki 100Gi / SeaweedFS 500Gi → actually 10Gi / 50Gi
+
+Also stale: `foundry/stack.yaml` `setup_state.openbao_installed/initialized: true` persists across
+rebuilds and will lie to Foundry on reinstall.
+
+`k8s/monitoring/persistent-volumes.yaml` declares local-storage PVs pinned to a node named
+`worker-1` that has never existed in this cluster. **Recommend deleting** — actively misleading.
+
+---
+
+## 6. Recommended order of operations
+
+1. **Verify `/etc/rancher/k3s/registries.yaml` on all three nodes** (I could not — SSH refused).
+2. **Rebuild and push all Zot images.** Nothing app-level works until the catalog is non-empty.
+3. **Fix the dual-default StorageClass** before creating any new PVCs.
+4. **Install cert-manager**, then re-scope the kube-vip pool to a free 192.168.1.x range and
+   convert `contour-envoy` to `type: LoadBalancer`. Order matters — TLS first.
+5. **Purge SeaweedFS filer metadata** → unblocks Loki and Velero.
+6. **Fix backups properly**: `deployNodeAgent: true`, `defaultVolumesToFsBackup: true`, install CSI
+   snapshot CRDs, set a Longhorn backup target, and **add an off-cluster destination**. Then take a
+   backup and *test a restore* — an untested backup is a hypothesis.
+7. **Re-init OpenBAO** and repopulate from 1Password; set the PV reclaim policy to `Retain` first.
+8. Redeploy apps in the dependency order in §3.
+9. Rotate the PowerDNS key and the shared S3 credentials.
+10. Update the docs in §5 — or delete them. Documentation describing a nonexistent recovery path
+    is worse than none, because it will be trusted during an incident.

--- a/docs/manual-changes-2026-08-03.md
+++ b/docs/manual-changes-2026-08-03.md
@@ -1,0 +1,312 @@
+# Manual Changes — 2026-08-03
+
+Changes made by hand during the post-rebuild audit. Companion to
+[`cluster-audit-2026-08-03.md`](./cluster-audit-2026-08-03.md).
+
+Two kinds of change are recorded here:
+
+- **Live cluster patches** — imperative `kubectl` changes that are NOT yet reflected in any
+  declarative source, and will be lost on a rebuild unless the paired Foundry config change
+  is applied.
+- **Config changes** — edits to `~/.foundry/stack.yaml` and dotfiles that make the fix durable.
+
+> `~/.foundry/stack.yaml` is **outside this git repo** and is therefore not version-controlled.
+> The edits below exist only on this machine. Consider vendoring a sanitized copy into the repo
+> (it currently contains plaintext S3 and PowerDNS credentials — see the audit doc §4).
+
+---
+
+## 1. Default StorageClass — `local-path` demoted
+
+### Problem
+Both `local-path` (k3s built-in) and `longhorn` were annotated
+`storageclass.kubernetes.io/is-default-class: "true"`. With two defaults, a PVC that omits
+`storageClassName` binds **nondeterministically** — a workload expecting replicated Longhorn
+storage could silently land on single-node, non-replicated `local-path`.
+
+### Live change applied
+```bash
+export KUBECONFIG=~/.foundry/kubeconfig
+kubectl patch storageclass local-path \
+  -p '{"metadata":{"annotations":{"storageclass.kubernetes.io/is-default-class":"false"}}}'
+```
+
+Result — `longhorn` is now the sole default:
+```
+NAME              PROVISIONER             DEFAULT
+local-path        rancher.io/local-path   false
+longhorn          driver.longhorn.io      true
+longhorn-static   driver.longhorn.io      <none>
+```
+
+### Why the patch alone is not enough
+`local-path` is owned by a **k3s Addon**, not by Helm or Foundry:
+```
+objectset.rio.cattle.io/owner-gvk:       k3s.cattle.io/v1, Kind=Addon
+objectset.rio.cattle.io/owner-name:      local-storage
+spec.source:  /var/lib/rancher/k3s/server/manifests/local-storage.yaml
+```
+k3s reconciles that manifest by checksum. The patch holds for now, but a k3s upgrade that
+rewrites `local-storage.yaml` will restore `is-default-class: true` and reintroduce the bug.
+
+### Durable fix — applied to `~/.foundry/stack.yaml`
+```yaml
+components:
+    k3s:
+        # NOTE: 'disable' REPLACES foundry's defaults (traefik, servicelb) rather than
+        # appending, so both must be listed explicitly here.
+        disable:
+            - traefik
+            - servicelb
+            - local-storage
+        installed: true
+```
+
+Two things worth knowing about this key:
+
+- Foundry parses `disable` at `v1/internal/component/k3s/types.go:93` and it **overwrites** the
+  built-in default `["traefik","servicelb"]` — omitting either would re-enable it.
+- `local-storage` is a supported value (exercised in `v1/internal/component/k3s/types_test.go:77`).
+
+**Foundry gap worth reporting upstream:** `storage.set_default: true` only sets `defaultClass`
+on the *Longhorn* chart (`v1/internal/component/storage/install.go:453`). There is no code path
+that unsets k3s's `local-path` default, so Foundry alone cannot produce a single-default cluster.
+Disabling the k3s addon is the workaround.
+
+### Not yet applied
+The `disable` list only takes effect when k3s is reinstalled/reconfigured. The running cluster
+still has the `local-storage` addon active — the live patch above is what is holding the line.
+Applying it requires a k3s server config change and restart on `blue1`:
+```bash
+foundry component install k3s    # verify intent first; this touches the control plane
+```
+
+---
+
+## 2. Zot registry — relocated onto persistent storage
+
+### Problem
+The registry catalog is empty after the rebuild:
+```bash
+$ curl http://100.81.89.62:5000/v2/_catalog   →  {"repositories":[]}
+$ curl http://192.168.1.185:5000/v2/_catalog  →  {"repositories":[]}
+```
+Zot is **reachable on both addresses**, so this is not a connectivity fault — the registry's
+**storage did not survive**. Every private image is gone, which is why all workloads in
+`chatbot` and `redditwatch` are in `ImagePullBackOff`.
+
+### Root cause
+Zot is **not a Kubernetes workload**. Foundry runs it as a plain Docker container on the host
+holding the `zot` role (`v1/internal/component/zot/install.go:155`):
+```
+docker run --name foundry-zot -p 5000:5000 \
+  -v /var/lib/foundry-zot:/var/lib/zot \
+  -v /etc/foundry-zot:/etc/zot/config.json ...
+```
+Default data dir is `/var/lib/foundry-zot` (`v1/internal/component/zot/types.go:94`) — the host
+**root filesystem** of blue1. It has no PVC, so it is covered by neither Longhorn replication
+nor Velero. Rebuilding the host wipes the registry.
+
+### Durable fix — applied to `~/.foundry/stack.yaml`
+```yaml
+components:
+    zot:
+        installed: true
+        storage:
+            mount_path: /data/persistent-storage/zot
+```
+`storage.mount_path` overrides the container's data dir
+(`v1/internal/component/zot/install.go:108-109`), placing image blobs on persistent storage
+instead of the ephemeral host root.
+
+> **Verify before applying.** The `zot` role is on **blue1**, but the audit found the 2TB disk
+> (`data-disk-001`, 1.6TB) is on **refurb** — blue1 has only a ~105GB root disk. Confirm that
+> `/data/persistent-storage` actually exists on blue1 and is backed by durable storage. If it is
+> not, either move the `zot` role to `refurb` or point `mount_path` at a real persistent mount on
+> blue1. Setting this to a path on the same ephemeral root disk fixes nothing.
+
+### Still required — config alone does not restore images
+Relocating storage prevents the *next* loss; it does not recover what is already gone. There is
+no backup of the registry (see audit §1.1). **Every private image must be rebuilt and re-pushed:**
+
+```bash
+# example, per ~/code/pedro/iam_pedro/deployment/README.md
+cd ~/code/pedro/iam_pedro && TAG=$(git rev-parse --short HEAD)
+for SERVICE in discord twitch keepalive; do
+  podman build --platform linux/amd64 -f cli/${SERVICE}/${SERVICE}Bot.Dockerfile \
+    -t 100.81.89.62:5000/pedro-${SERVICE}:${TAG} .
+  podman push --tls-verify=false 100.81.89.62:5000/pedro-${SERVICE}:${TAG}
+done
+
+curl -s http://100.81.89.62:5000/v2/_catalog   # must be non-empty before redeploying
+```
+Also needed: `pedro-mempalace`, `redditwatch`, and the `pedro-tag` images.
+
+### Unverified — check this before assuming pushes are sufficient
+Pull failures read `Head "https://100.81.89.62:5000/..."` (HTTPS) while Zot serves plain **HTTP**,
+which suggests `/etc/rancher/k3s/registries.yaml` was lost in the rebuild. **This could not be
+confirmed — SSH to all three nodes was refused (publickey).** Verify on each node:
+```bash
+cat /etc/rancher/k3s/registries.yaml
+```
+If absent, images will still fail to pull after being pushed. The repo has a template at
+`scripts/k8s/registries.yaml`, but note it hardcodes the **old** Tailscale IPs and needs updating
+to the current LAN addresses before use.
+
+---
+
+## 3. Dotfiles — KUBECONFIG and foundry PATH
+
+### KUBECONFIG pointed at a nonexistent file
+Two stale references, both corrected to `~/.foundry/kubeconfig`:
+
+| File | Was | Now |
+|---|---|---|
+| `~/dotfiles/zsh/zsh_profile:7` | `~/.kube/pedro-ops-config` | `~/.foundry/kubeconfig` |
+| `~/dotfiles/CLAUDE.md:81` | `~/kubeconfig` | `~/.foundry/kubeconfig` |
+
+`~/dotfiles/zsh/zshrc:171` was already correct, which is why kubectl worked despite the above.
+
+### foundry PATH — stale entry removed, duplicate collapsed
+`~/dotfiles/zsh/zshrc:8` pointed at `$HOME/code/cli/foundry`, which **does not exist**. A second,
+correct entry later in the file was masking the problem. Consolidated to one entry at the top:
+
+```bash
+# Foundry CLI -- built from source at ~/code/opensource/foundry/v1
+# (rebuild: cd ~/code/opensource/foundry/v1 && go build -o foundry ./cmd/foundry)
+export PATH="$HOME/code/opensource/foundry/v1:$PATH"
+```
+The duplicate at former line 171 was replaced with a pointer comment.
+
+### foundry rebuilt from source
+```bash
+cd ~/code/opensource/foundry/v1 && go build -o foundry ./cmd/foundry
+```
+Note the module root is `v1/`, not the repo root — `go build ./...` from the repo root fails with
+`directory prefix . does not contain main module`.
+
+Verified in a fresh login shell:
+```
+$ zsh -lc 'which foundry && foundry --version && echo $KUBECONFIG'
+/Users/soypete/code/opensource/foundry/v1/foundry
+foundry version dev
+/Users/soypete/.foundry/kubeconfig
+```
+
+---
+
+## 3a. OpenWebUI stack — deployed and automated
+
+Deployed the full OpenWebUI stack and captured every step in scripts, so a future rebuild does
+not depend on anyone remembering the order.
+
+### New scripts
+
+| Script | Purpose |
+|---|---|
+| `scripts/setup-seaweedfs-buckets.sh` | Idempotently create the S3 buckets the stack needs (`loki`, `velero`, `openwebui`, `openwebui-pg`). Bucket creation was previously an undocumented manual step. |
+| `scripts/deploy-openwebui.sh` | End-to-end OpenWebUI deploy in dependency order. Idempotent and safe to re-run. |
+| `skaffold.yaml` | Declarative deploy profiles (`infra`, `openwebui`, `embed`). **Unvalidated** — skaffold is not installed on the admin machine. The scripts remain the source of truth. |
+
+### What got deployed
+
+```
+openwebui-db-1                  1/1  Running   # CNPG primary
+openwebui-db-2                  1/1  Running   # CNPG replica
+openwebui-open-webui-*          1/1  Running
+openwebui-open-webui-redis-*    1/1  Running
+openwebui-pipelines-*           1/1  Running
+openwebui-tika-*                1/1  Running
+```
+
+Verified: DB migrations ran (`Seeded 380 new config defaults`) and the app serves HTTP 200.
+
+### Deployment method (answers "why isn't Postgres a Helm chart?")
+
+- **Helm** — CNPG operator (`cnpg/cloudnative-pg`), OpenWebUI (`open-webui/open-webui`).
+  Redis, Tika and pipelines are **subcharts** of open-webui, not separate releases.
+- **kubectl** — `openwebui-db` is a **Cluster CR**, not a chart. CNPG's `cloudnative-pg` chart
+  ships only the operator; databases are declared as CRs. This is also what
+  `docs/maintenance.md:78` has always documented.
+
+### Bugs found and fixed
+
+| Issue | Detail |
+|---|---|
+| **Redis contradiction** | `redis.enabled: false` while `websocket.manager: redis` — websockets pointed at a Redis that was never deployed. Now `enabled: true`; the chart renders `openwebui-open-webui-redis`. |
+| **S3 port wrong** | `values.yaml` used `seaweedfs-s3:8332`; the live service port is **8333**. Present since the original commit (`7d9f718`) — it never worked. Now uses the FQDN + 8333. |
+| **Plaintext PG password in git** | `postgres.yaml:29` had the superuser password in `postInitSQL`. Replaced with `superuserSecret`, password rotated, and the line removed. |
+| **Duplicate env vars** | `OLLAMA_BASE_URLS` / `ENABLE_OLLAMA_API` in `extraEnvVars` collided with values the chart sets from `ollama.enabled: false`, producing *"hides previous definition … may be dropped"*. Removed; the chart handles them. |
+| **pgvector missing** | `postInitSQL` runs only on **first bootstrap**, so `CREATE EXTENSION vector` never applied. The image does ship pgvector (`vector 0.8.0`) — it just needed running. The script now does this idempotently. |
+| **Superuser password mismatch** | The cluster bootstrapped **before** `superuserSecret` existed, so CNPG kept its bootstrap password and did **not** retroactively adopt the Secret. OpenWebUI crashlooped with `FATAL: password authentication failed for user "postgres"`. Fixed with `ALTER USER`; the script now detects and repairs this automatically. |
+
+### SeaweedFS split-brain — partially resolved, one manual step outstanding
+
+Recreating the `loki` bucket did **not** clear the fault. The bucket's *contents* survived:
+`/buckets/loki/` still held `loki_cluster_seed.json`, 12 `index/` dirs and ~1605 `fake/` chunk
+dirs, all referencing volumes (12, 14, …) that no longer exist — the volume server reports
+`"Volumes":0`. Every read of those objects returns HTTP 500.
+
+The underlying log data is **unrecoverable** regardless; only dead metadata remains.
+
+**Outstanding manual step** (the delete was blocked as a destructive operation, deliberately —
+run it yourself after confirming):
+
+```bash
+# Verify the data is genuinely orphaned first:
+kubectl -n seaweedfs exec seaweedfs-filer-0 -- \
+  sh -c "echo 'fs.meta.cat /buckets/loki/loki_cluster_seed.json' | weed shell" | grep volumeId
+kubectl -n seaweedfs exec seaweedfs-master-0 -- wget -qO- http://localhost:9333/dir/status
+
+# Then clear and recreate:
+kubectl -n seaweedfs exec seaweedfs-filer-0 -- \
+  sh -c "echo 's3.bucket.delete -name loki' | weed shell"
+./scripts/setup-seaweedfs-buckets.sh loki
+kubectl -n loki delete pod loki-0
+```
+
+Until this is done `loki-0` stays in CrashLoopBackOff on `init compactor: failed to get s3 object`.
+
+### Still outstanding for OpenWebUI
+
+- **No ingress.** `ingress.enabled: false` and Tailscale (the intended path) is gone. Access is
+  `kubectl -n openwebui port-forward svc/openwebui-open-webui 8080:8080`.
+- **No backups** for `openwebui-db` — tracked in [issue #13](https://github.com/Soypete/pedro-ops/issues/13).
+- **Shared S3 credentials.** `openwebui-secrets` reuses the one key pair that Loki, Velero and
+  SeaweedFS all share, so any component can delete another's objects. Read from
+  `~/.foundry/stack.yaml` because no Kubernetes Secret holds them. Splitting into per-app
+  least-privilege credentials is still TODO.
+- **`WEBUI_SECRET_KEY` is generated** if absent. Save it to 1Password — losing it invalidates
+  all sessions. There is no `openwebui` S3 item in 1Password today (only an `openweb ui` login).
+
+---
+
+## 4. Validation performed
+
+```bash
+$ foundry config validate
+✓ Configuration is valid: /Users/soypete/.foundry/stack.yaml
+  Cluster: test (local)
+  Hosts: 3
+  Components: 15
+```
+
+Both `stack.yaml` edits parse cleanly. **Neither has been applied to the cluster yet** — they take
+effect on the next `foundry component install` for k3s and zot respectively.
+
+---
+
+## 5. Outstanding — stale data in `stack.yaml`
+
+Not changed, because correcting them affects how Foundry reaches the hosts and should be a
+deliberate decision rather than a side effect of this cleanup:
+
+- `hosts:` still lists the **dead Tailscale IPs** (`blue1: 100.81.89.62`, `blue2: 100.125.196.1`,
+  `refurb: 100.70.90.12`). The cluster now lives on `192.168.1.185/.97/.253`. Note blue2 and
+  refurb are also **swapped** relative to reality.
+- `cluster.vip: 100.81.89.100` — the actual VIP is `10.0.0.11`.
+- `setup_state.openbao_installed: true` and `openbao_initialized: true` — both false now; these
+  will mislead Foundry into skipping initialization on reinstall.
+- Plaintext S3 credentials (~5 occurrences, one key pair shared by Loki, SeaweedFS, and Velero)
+  and the PowerDNS API key. Both should be rotated and moved behind the `${secret:...}`
+  indirection that `stack.yaml` already uses for `dns.api_key`.

--- a/docs/manual-changes-2026-08-03.md
+++ b/docs/manual-changes-2026-08-03.md
@@ -281,6 +281,112 @@ Until this is done `loki-0` stays in CrashLoopBackOff on `init compactor: failed
 
 ---
 
+## 3b. Tailscale operator — installed, blocked on expired OAuth credentials
+
+The manifest for `https://ai.tail6fbc5.ts.net` **already existed** and is correct:
+`k8s/tailscale/openwebui-ingress.yaml` targets `ai.tail6fbc5.ts.net` with backend
+`openwebui-open-webui:8080`. It could not work because the operator was absent — there was no
+`tailscale` IngressClass for it to bind to.
+
+Installed the operator (`tailscale/tailscale-operator` into ns `tailscale`, credentials read
+from 1Password items `TS_CLIENT_ID` / `TS_CLIENT_SECRET`). The CRDs and IngressClass registered
+successfully:
+
+```
+NAME        CONTROLLER
+tailscale   tailscale.com/ts-ingress
++ connectors, dnsconfigs, proxyclasses, proxygroups, recorders, tailnets .tailscale.com
+```
+
+**But the operator cannot authenticate.** It crashlooped with:
+
+```
+creating operator authkey: Post "https://controlplane.tailscale.com/api/v2/tailnet/-/keys":
+oauth2: cannot fetch token: 401 Unauthorized
+Response: {"message":"API token invalid"}
+```
+
+Verified independently against Tailscale's own endpoint — not a cluster or config problem:
+
+```
+$ curl -X POST https://api.tailscale.com/api/v2/oauth/token \
+    -d client_id=... -d client_secret=...
+HTTP 401
+```
+
+The stored OAuth credentials (last edited ~5 months ago) have been **revoked or expired**.
+
+The operator Deployment was **scaled to 0** to avoid a permanent crashloop. CRDs and the
+IngressClass remain installed, so applying the ingress manifests now would leave them pending
+rather than failing admission.
+
+### To finish
+
+1. Mint new OAuth credentials at https://login.tailscale.com/admin/settings/oauth
+   (scopes: `devices`, `auth_keys`; tag `tag:k8s-pedro-ops`).
+2. Update the `TS_CLIENT_ID` / `TS_CLIENT_SECRET` items in the `pedro` 1Password vault.
+3. Re-run:
+   ```bash
+   export TS_CLIENT_ID="$(op read 'op://pedro/TS_CLIENT_ID/credential')"
+   export TS_CLIENT_SECRET="$(op read 'op://pedro/TS_CLIENT_SECRET/credential')"
+   helm upgrade --install tailscale-operator tailscale/tailscale-operator -n tailscale \
+     --set oauth.clientId="$TS_CLIENT_ID" --set oauth.clientSecret="$TS_CLIENT_SECRET"
+   kubectl -n tailscale scale deploy operator --replicas=1
+   kubectl apply -f k8s/tailscale/openwebui-ingress.yaml
+   ```
+4. Confirm the ingress gets an address, then browse to `https://ai.tail6fbc5.ts.net`.
+
+Note the ACL policy in `k8s/tailscale/acl-policy.json` and the `Connector` /`DNSConfig` in that
+directory also assume the pre-rebuild tailnet; re-check them once the operator authenticates.
+
+---
+
+## 3c. OpenBAO — correction: it survived, and now holds the OpenWebUI secrets
+
+**The audit's original "OpenBAO is gone" finding was wrong**, and
+`docs/cluster-audit-2026-08-03.md` §1.5 has been corrected. OpenBAO is a *host-level* Foundry
+component (no k8s PVC by design) and it survived the rebuild:
+
+```
+$ curl http://100.70.90.12:8200/v1/sys/health
+{"initialized": true, "sealed": false, "version": "2.0.0", "cluster_name": "vault-cluster-5896ff57"}
+
+$ foundry component status openbao
+Healthy: true   Message: healthy (initialized, unsealed)
+```
+
+The root token in `~/.foundry/openbao-keys/test/keys.json` authenticates, and the `foundry-core/`
+KV mount is intact. **No re-initialization is needed.** The error was inferring destruction from
+an absent PVC — but OpenBAO never had one, because it never ran in Kubernetes. Note the live
+address is the *old* Tailscale IP `100.70.90.12`; `100.81.89.62:8200` is dead because that host
+is gone.
+
+### New script: `scripts/sync-openwebui-secrets-to-openbao.sh`
+
+`WEBUI_SECRET_KEY` was generated at deploy time and existed **only** in a Kubernetes Secret —
+losing it invalidates every OpenWebUI session. Same exposure for the Postgres superuser password.
+These are cluster secrets, so they belong in OpenBAO.
+
+The script reads the live k8s secrets and writes them to `foundry-core/apps/openwebui` and
+`foundry-core/apps/openwebui-db`. It never reads values back out or prints them. Supports
+`DRY_RUN=1`, which has been verified:
+
+```
+[dry-run] would write foundry-core/apps/openwebui    keys: WEBUI_SECRET_KEY,DATABASE_URL,AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY
+[dry-run] would write foundry-core/apps/openwebui-db keys: username,password
+```
+
+**Not yet executed against OpenBAO** — the write uses the root token, so run it yourself:
+
+```bash
+export KUBECONFIG=~/.foundry/kubeconfig
+./scripts/sync-openwebui-secrets-to-openbao.sh
+```
+
+Prefer a scoped token via `$VAULT_TOKEN` over the root token for routine use.
+
+---
+
 ## 4. Validation performed
 
 ```bash

--- a/docs/secrets-playbook.md
+++ b/docs/secrets-playbook.md
@@ -211,6 +211,83 @@ This approach is **not recommended** because:
 - Requires 1Password connectivity from pods
 - No centralized audit trail
 
+## Kei Project Secrets
+
+### GitHub OAuth Credentials
+
+The Kei project uses GitHub OAuth for authentication. Credentials are stored in OpenBAO and injected via the OpenBAO Agent Injector.
+
+#### 1. Get credentials from 1Password
+
+```bash
+# Get GitHub Client ID
+op item get "kei_github_clientID" --vault pedro --reveal
+
+# Get GitHub OAuth Secret
+op item get "kai_github_oauth_secret" --vault pedro --reveal
+```
+
+#### 2. Store in OpenBAO
+
+```bash
+# Using kubectl with a temporary pod to access OpenBAO
+kubectl run --rm -it tmp-shell --image=busybox --restart=Never -- sh -c "
+wget -q -O - --header='X-Vault-Token: <root-token>' --header='Content-Type: application/json' \
+  --post-data='{\"data\": {\"client_id\": \"<client_id>\", \"client_secret\": \"<client_secret>\"}}' \
+  http://100.81.89.62:8200/v1/secret/data/kei/github
+"
+```
+
+Or using Foundry's OpenBAO token (stored in `~/.foundry/openbao-keys/<cluster>/keys.json`):
+
+```bash
+# Get root token
+ROOT_TOKEN=$(cat ~/.foundry/openbao-keys/test/keys.json | jq -r '.root_token')
+
+# Store secrets
+kubectl run --rm -it tmp-shell --image=busybox --restart=Never -- sh -c "
+wget -q -O - --header='X-Vault-Token: $ROOT_TOKEN' --header='Content-Type: application/json' \
+  --post-data='{\"data\": {\"client_id\": \"Ov23liJn1c5XbeACMmKA\", \"client_secret\": \"<secret>\"}}' \
+  http://100.81.89.62:8200/v1/secret/data/kei/github
+"
+```
+
+#### 3. Enable namespace for injection
+
+By default, the OpenBAO injector ignores certain namespaces. Enable it for kei:
+
+```bash
+kubectl annotate namespace kei openbao.hashicorp.com/webhook-ignore-namespaces=false --overwrite
+```
+
+#### 4. Add annotations to deployment
+
+In `k8s/base/oidc-bridge/deployment.yaml`:
+
+```yaml
+template:
+  metadata:
+    annotations:
+      openbao.hashicorp.com/agent-inject: "true"
+      openbao.hashicorp.com/role: "kei"
+      openbao.hashicorp.com/agent-inject-secret-github: "secret/data/kei/github"
+      openbao.hashicorp.com/agent-inject-template-github: |
+        {{- with secret "secret/data/kei/github" -}}
+        export GITHUB_CLIENT_ID="{{ .Data.data.client_id }}"
+        export GITHUB_CLIENT_SECRET="{{ .Data.data.client_secret }}"
+        {{- end }}
+```
+
+#### 5. Create GitHub OAuth App
+
+Go to https://github.com/settings/developers and create a new OAuth app:
+
+- **Application name**: kei
+- **Homepage URL**: `https://kei-web-ingress.tail6fbc5.ts.net`
+- **Authorization callback URL**: `https://kei-web-ingress.tail6fbc5.ts.net/auth/callback`
+
+Use the client ID and secret from 1Password (step 1) when creating the app.
+
 ## References
 
 - [OpenBAO Agent Injector](https://developer.hashicorp.com/vault/docs/platform/k8s/injector)

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -302,12 +302,12 @@ worker-2        Ready    <none>                 4m    v1.28.5+k3s1
 
 ```bash
 # Export kubeconfig
-export KUBECONFIG=~/.kube/pedro-ops-config
+export KUBECONFIG=~/.foundry/kubeconfig
 
 # Add to your shell profile for persistence
-echo 'export KUBECONFIG=~/.kube/pedro-ops-config' >> ~/.bashrc
+echo 'export KUBECONFIG=~/.foundry/kubeconfig' >> ~/.bashrc
 # or for zsh:
-echo 'export KUBECONFIG=~/.kube/pedro-ops-config' >> ~/.zshrc
+echo 'export KUBECONFIG=~/.foundry/kubeconfig' >> ~/.zshrc
 ```
 
 ### Step 3.3: Verify Cluster

--- a/helm/moonshine-stt/Chart.yaml
+++ b/helm/moonshine-stt/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: moonshine-stt
+description: Moonshine v2 speech-to-text served over the OpenAI audio API (CPU-only)
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - speech-to-text
+  - moonshine
+  - openai-compatible

--- a/helm/moonshine-stt/RUNBOOK.md
+++ b/helm/moonshine-stt/RUNBOOK.md
@@ -1,0 +1,218 @@
+# Moonshine STT — Runbook
+
+Self-hosted speech-to-text for Open WebUI. Moonshine v2 behind a small
+OpenAI-compatible API, CPU-only.
+
+| | |
+|---|---|
+| Namespace | `moonshine` |
+| Helm release | `moonshine-stt` (chart `helm/moonshine-stt`) |
+| Service | `moonshine-stt.moonshine.svc.cluster.local:8000` |
+| Image | `100.81.89.62:5000/moonshine-stt:0.1.0` (built from `docker/moonshine-stt/`) |
+| Model | `small-streaming` (English), baked into the image |
+| Consumer | Open WebUI, via `AUDIO_STT_*` env in `helm/openwebui/values.yaml` |
+
+## Architecture
+
+Moonshine ships no server, and Open WebUI speaks the OpenAI audio API, so
+`docker/moonshine-stt/app.py` is the adapter between them:
+
+- `POST /v1/audio/transcriptions` — OpenAI multipart shape. Accepts
+  wav/mp3/ogg/webm/m4a and transcodes to 16 kHz mono via ffmpeg before
+  inference. Supports `response_format=json` (default) and `text`. Fields
+  Moonshine cannot honour (`prompt`, `temperature`, `timestamp_granularities`)
+  are accepted and ignored rather than erroring — clients send them routinely.
+- `GET /healthz` — 200 only after the model is resident; 503 while loading.
+  Both probes point here, so traffic never reaches a cold pod.
+- `GET /v1/models` — some OpenAI clients probe this first.
+
+Inference is serialised behind an `asyncio` lock (Moonshine is not documented
+thread-safe) and the container runs a single uvicorn worker. **Scale with
+replicas, not workers.**
+
+## Measured performance
+
+Measured on this cluster, 5.40 s of speech, `small-streaming`:
+
+| CPU limit | RTF | Wall clock |
+|---|---|---|
+| 2 cores | **1.00 – 1.73** | 5.4 – 9.3 s |
+| 3 cores (current) | **0.53 – 0.74** | 2.9 – 4.0 s |
+
+RTF tracks the CPU limit almost linearly — a single transcription pegs the
+limit, so the pod is throttle-bound, not memory-bound. At `cpu: 2` transcription
+took *as long as the audio itself*; `cpu: 3` is roughly 2× faster and comfortably
+faster than realtime.
+
+For reference, the same clip on an M-series Mac (emulated amd64) hit RTF 0.068 —
+about 20× faster than these nodes. **Do not size from a laptop measurement.**
+
+Memory peaked at ~535 Mi against a 2 Gi limit, so memory has plenty of headroom.
+
+Cold start: model load is well under a second (weights are local, not
+downloaded), plus ~10-20 s for image pull and Python import on first schedule.
+The readiness probe's `initialDelaySeconds: 20` covers this.
+
+## Resource tuning
+
+Start here before changing anything:
+
+```bash
+kubectl top pods -n moonshine          # is CPU pinned at the limit?
+kubectl -n moonshine logs -l app.kubernetes.io/name=moonshine-stt \
+  -c moonshine-stt | grep rtf=          # per-request RTF
+```
+
+- **CPU at the limit + RTF > 1** → raise `resources.limits.cpu`. Nodes `blue1`
+  and `blue2` have 4 cores, `refurb` has 8, so going past 3 on the small nodes
+  will starve other workloads.
+- **Many concurrent users** → raise `replicaCount`. Each pod serialises its own
+  inference, so concurrency comes from replicas.
+- Memory is not the constraint at `small-streaming`; leave 1 Gi/2 Gi alone
+  unless you move to `medium-streaming`.
+
+## Bumping the model
+
+The model is **baked into the image**, so `values.yaml` alone will not change
+it — the env var only tells the app which baked model to load. Rebuild:
+
+```bash
+cd docker/moonshine-stt
+podman build --platform linux/amd64 \
+  --build-arg MOONSHINE_MODEL=medium-streaming \
+  -t 100.81.89.62:5000/moonshine-stt:0.2.0 .
+podman push --tls-verify=false 100.81.89.62:5000/moonshine-stt:0.2.0
+```
+
+Then update `helm/moonshine-stt/values.yaml`:
+
+```yaml
+image:
+  tag: "0.2.0"
+model:
+  name: medium-streaming
+modelCacheSizeLimit: 1Gi     # medium is larger than small's ~160Mi
+```
+
+Valid `model.name` values (from `moonshine_voice.ModelArch`): `tiny`, `base`,
+`tiny-streaming`, `base-streaming`, `small-streaming`, `medium-streaming`.
+Accuracy/size tradeoff: tiny 34M/12.0% WER, small 123M/7.84% WER,
+medium 245M/6.65% WER. **Medium will roughly double RTF — re-measure before
+committing to it on these CPUs.**
+
+Then `helm upgrade moonshine-stt helm/moonshine-stt -n moonshine` and re-run
+the smoke test below.
+
+## Smoke test
+
+```bash
+kubectl -n moonshine port-forward svc/moonshine-stt 8899:8000 &
+curl -s http://localhost:8899/healthz
+# {"status":"ok","model":"small-streaming","language":"en"}
+
+say --data-format=LEI16@16000 --channels=1 -o /tmp/t.wav "testing one two three"
+curl -s -F "file=@/tmp/t.wav" http://localhost:8899/v1/audio/transcriptions
+# {"text":"Testing one two three"}
+```
+
+End-to-end through Open WebUI's own code path:
+
+```bash
+kubectl -n openwebui exec deploy/openwebui-open-webui -c open-webui -- python -c "
+import asyncio, types
+from open_webui.routers.audio import transcribe
+class App: state = types.SimpleNamespace()
+class Req:
+    app = App()
+    def __init__(self): self.state = types.SimpleNamespace()
+asyncio.run(transcribe(Req(), '/tmp/speech.webm', {}, None))"
+```
+
+## Open WebUI wiring
+
+Set in `helm/openwebui/values.yaml` (Helm-managed — do not `kubectl edit`):
+
+```yaml
+AUDIO_STT_ENGINE=openai
+AUDIO_STT_MODEL=small-streaming
+AUDIO_STT_OPENAI_API_BASE_URL=http://moonshine-stt.moonshine.svc.cluster.local:8000/v1
+AUDIO_STT_OPENAI_API_KEY=moonshine-local   # unused; service is unauthenticated
+```
+
+These env vars *seed* persisted config keys (`audio.stt.engine` etc). On this
+cluster the upgrade did propagate to the stored config — verify after any
+change:
+
+```bash
+kubectl -n openwebui exec deploy/openwebui-open-webui -c open-webui -- python -c "
+import asyncio
+from open_webui.config import Config
+asyncio.run(Config.get('audio.stt.engine'))"
+```
+
+If a future upgrade does *not* propagate, set it in
+**Admin → Settings → Audio** instead; the stored value wins over env.
+
+## Known issues
+
+### `refurb` cannot pull from the Zot registry
+
+One replica lands on `refurb` and fails:
+
+```
+failed to pull ... http: server gave HTTP response to HTTPS client
+```
+
+`refurb` is missing `/etc/rancher/k3s/registries.yaml`; `blue1` and `blue2`
+have it. This is a **node defect, not a chart problem** — it affects any
+workload pulling from `100.81.89.62:5000`. Fix on the node:
+
+```bash
+# on refurb, as root
+cat > /etc/rancher/k3s/registries.yaml <<'EOF'
+mirrors:
+  "100.81.89.62:5000":
+    endpoint:
+      - "http://100.81.89.62:5000"
+configs:
+  "100.81.89.62:5000":
+    tls:
+      insecure_skip_verify: true
+EOF
+systemctl restart k3s-agent
+```
+
+Until then the service runs with one healthy replica; scheduling still works
+because `blue1`/`blue2` pull fine.
+
+### Auth is not enabled
+
+The service is unauthenticated inside the cluster and has no Ingress. If you
+expose it, create a Secret out-of-band (the cluster has no External Secrets or
+1Password operator — secrets are plain Opaque, created by script) and set:
+
+```yaml
+auth:
+  existingSecret: moonshine-stt-auth
+  secretKey: API_TOKEN
+```
+
+The chart never holds the token value. **Note the server does not yet enforce
+the token** — `app.py` would need a dependency added to check it.
+
+## Gotchas worth remembering
+
+- **`readOnlyRootFilesystem` breaks model loading.** `moonshine-voice` uses
+  `filelock` and writes a `.lock` beside each weight file even when only
+  reading. An init container copies the baked cache to a writable `emptyDir`
+  and `XDG_CACHE_HOME` points there. This did not reproduce locally under
+  podman, which runs writable.
+- Use `cp -r`, not `cp -a`, in that init container — preserving timestamps onto
+  the emptyDir mount root fails with `Operation not permitted`.
+- `Transcript.text` embeds `[0.00s]` timestamp prefixes. The app joins
+  `line.text` instead so callers get clean prose.
+- `helm ... --wait` on a slow rollout can exceed a 2-minute tool timeout and
+  leave the release `pending-upgrade`, blocking further upgrades. Recover with
+  `helm rollback`, or `helm uninstall` + reinstall if rollback also wedges.
+- The package is **`moonshine-voice`** (MIT). `useful-moonshine` is the 2024
+  package and PyPI `moonshine` is an unrelated project.

--- a/helm/moonshine-stt/templates/_helpers.tpl
+++ b/helm/moonshine-stt/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{- define "moonshine-stt.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "moonshine-stt.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "moonshine-stt.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{ include "moonshine-stt.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "moonshine-stt.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "moonshine-stt.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/helm/moonshine-stt/templates/deployment.yaml
+++ b/helm/moonshine-stt/templates/deployment.yaml
@@ -1,0 +1,134 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "moonshine-stt.fullname" . }}
+  labels:
+    {{- include "moonshine-stt.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "moonshine-stt.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "moonshine-stt.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        # The model weights are baked into the image, but moonshine-voice uses
+        # filelock and writes a sibling .lock file next to each weight before
+        # reading it -- which fails under readOnlyRootFilesystem. Copy the cache
+        # onto a writable emptyDir so the rootfs stays read-only.
+        # No network access: this is a local copy, not a download.
+        - name: seed-model-cache
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          command:
+            - sh
+            - -c
+            # cp -r, not -a: preserving timestamps onto the emptyDir mount root
+            # fails with "Operation not permitted", and mtimes are irrelevant
+            # for read-only model weights.
+            - cp -r /home/moonshine/.cache/. /model-cache/ && echo "model cache seeded"
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-cache
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+      containers:
+        - name: moonshine-stt
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: MOONSHINE_MODEL
+              value: {{ .Values.model.name | quote }}
+            - name: MOONSHINE_LANGUAGE
+              value: {{ .Values.model.language | quote }}
+            # Point the library at the writable copy seeded by the init
+            # container (see note above).
+            - name: XDG_CACHE_HOME
+              value: /model-cache
+            {{- if .Values.auth.existingSecret }}
+            # Value lives only in the Secret; never in values.yaml or this chart.
+            - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.existingSecret }}
+                  key: {{ .Values.auth.secretKey }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          # Gates on model load: the endpoint returns 503 until Moonshine is
+          # resident, so no traffic reaches a cold pod.
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # readOnlyRootFilesystem is on, but ffmpeg needs scratch space to
+            # transcode uploads.
+            - name: tmp
+              mountPath: /tmp
+            - name: model-cache
+              mountPath: /model-cache
+      volumes:
+        - name: tmp
+          emptyDir:
+            sizeLimit: 1Gi
+        # Holds the copied model cache (~160Mi for small-streaming). Bump
+        # sizeLimit if you switch to medium-streaming.
+        - name: model-cache
+          emptyDir:
+            sizeLimit: {{ .Values.modelCacheSizeLimit }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # Spread replicas across nodes so one node loss does not take out STT.
+      # ScheduleAnyway: with refurb excluded there are only two eligible nodes,
+      # so this must not become a hard constraint.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "moonshine-stt.selectorLabels" . | nindent 14 }}

--- a/helm/moonshine-stt/templates/ingress.yaml
+++ b/helm/moonshine-stt/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+{{- /*
+  Off by default. Open WebUI reaches this service over cluster DNS, so
+  exposing it externally is opt-in only.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "moonshine-stt.fullname" . }}
+  labels:
+    {{- include "moonshine-stt.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "moonshine-stt.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/helm/moonshine-stt/templates/service.yaml
+++ b/helm/moonshine-stt/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "moonshine-stt.fullname" . }}
+  labels:
+    {{- include "moonshine-stt.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "moonshine-stt.selectorLabels" . | nindent 4 }}

--- a/helm/moonshine-stt/values.yaml
+++ b/helm/moonshine-stt/values.yaml
@@ -1,0 +1,96 @@
+replicaCount: 2
+
+image:
+  repository: 100.81.89.62:5000/moonshine-stt
+  tag: "0.1.0"
+  pullPolicy: IfNotPresent
+
+# Model baked into the image at build time. Changing this alone does NOT
+# change the served model -- rebuild the image with a matching
+# --build-arg MOONSHINE_MODEL, then bump image.tag. See RUNBOOK.md.
+model:
+  name: small-streaming
+  language: en
+
+# Weights are baked into the image but must be copied to a writable volume:
+# moonshine-voice writes .lock files beside them, which readOnlyRootFilesystem
+# forbids. small-streaming is ~160Mi; raise this for medium-streaming.
+modelCacheSizeLimit: 512Mi
+
+service:
+  type: ClusterIP
+  port: 8000
+
+# Measured on this cluster (see RUNBOOK.md): a single transcription pegs the
+# CPU limit, so RTF tracks the limit almost linearly. At cpu=2 RTF was ~1.0-1.7
+# (transcription takes as long as the audio); cpu=3 buys headroom on the 4-core
+# nodes without starving other workloads. Memory peaked ~535Mi, so 1Gi/2Gi is
+# generous and left alone.
+resources:
+  requests:
+    cpu: "1"
+    memory: 1Gi
+  limits:
+    cpu: "3"
+    memory: 2Gi
+
+# Model loads from local disk (baked in), but the probe is generous so a
+# slow/contended node cannot cause a restart loop during startup.
+probes:
+  readiness:
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+  liveness:
+    initialDelaySeconds: 90
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+
+# Optional bearer token for the API. The chart never holds the value --
+# create the Secret out-of-band (1Password -> kubectl) and name it here.
+# Leave existingSecret empty to run unauthenticated inside the cluster.
+auth:
+  existingSecret: ""
+  secretKey: API_TOKEN
+
+# Off by default: Open WebUI reaches this over cluster DNS.
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: ""
+  tls:
+    enabled: false
+    secretName: ""
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  fsGroup: 10001
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+nodeSelector: {}
+tolerations: []
+
+# TEMPORARY: refurb is missing /etc/rancher/k3s/registries.yaml, so it cannot
+# pull from the Zot registry ("http: server gave HTTP response to HTTPS
+# client"). This is a node defect affecting any workload pulling from
+# 100.81.89.62:5000 -- see RUNBOOK.md "Known issues" for the fix. Remove this
+# affinity block once the node is repaired.
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: NotIn
+              values: ["refurb"]
+
+extraEnv: []

--- a/helm/openwebui/values.yaml
+++ b/helm/openwebui/values.yaml
@@ -92,10 +92,21 @@ extraEnvVars:
     value: "ddg"
   - name: ENABLE_AUDIO_TTS
     value: "true"
-  - name: ENABLE_AUDIO_WHISPER
-    value: "true"
-  - name: WHISPER_API_URL
-    value: "http://whisper:9000"
+  # Speech-to-text via the self-hosted Moonshine v2 service (moonshine ns).
+  # Replaces ENABLE_AUDIO_WHISPER/WHISPER_API_URL, which pointed at a
+  # "whisper" service that never existed in this cluster.
+  # Engine value verified against the running image: routers/audio.py
+  # dispatches on audio.stt.engine == "openai".
+  - name: AUDIO_STT_ENGINE
+    value: "openai"
+  - name: AUDIO_STT_MODEL
+    value: "small-streaming"
+  - name: AUDIO_STT_OPENAI_API_BASE_URL
+    value: "http://moonshine-stt.moonshine.svc.cluster.local:8000/v1"
+  # Unused: the service is unauthenticated inside the cluster. Present because
+  # the OpenAI client requires a non-empty key.
+  - name: AUDIO_STT_OPENAI_API_KEY
+    value: "moonshine-local"
   - name: RAG_EMBEDDING_ENGINE
     value: "openai"
   - name: RAG_EMBEDDING_MODEL

--- a/helm/openwebui/values.yaml
+++ b/helm/openwebui/values.yaml
@@ -12,9 +12,12 @@ service:
 # Database - Supabase with pgvector
 databaseUrl: ""
 
-# Redis - use existing
+# Redis - bundled subchart of open-webui, used as the websocket message broker.
+# Must stay enabled while websocket.manager is "redis"; setting this false
+# points websockets at a Redis that is never deployed.
+# (For a single replica you could instead set manager: "" for the in-memory manager.)
 redis:
-  enabled: false
+  enabled: true
 
 websocket:
   enabled: true
@@ -45,7 +48,10 @@ persistence:
     accessKeyExistingAccessKey: AWS_ACCESS_KEY_ID
     secretKeyExistingSecret: openwebui-secrets
     secretKeyExistingSecretKey: AWS_SECRET_ACCESS_KEY
-    endpointUrl: "http://seaweedfs-s3:8332"
+    # Port is 8333 (svc seaweedfs-s3 port name 'swfs-s3'). Was 8332 since the
+    # original commit, which never matched the live service.
+    # FQDN so this resolves from the openwebui namespace.
+    endpointUrl: "http://seaweedfs-s3.seaweedfs.svc.cluster.local:8333"
 
 # OpenWebUI configuration
 extraEnvVars:
@@ -98,10 +104,11 @@ extraEnvVars:
     value: "false"
   - name: ENABLE_PGvector
     value: "false"
-  - name: OLLAMA_BASE_URLS
-    value: ""
-  - name: ENABLE_OLLAMA_API
-    value: "false"
+  # OLLAMA_BASE_URLS / ENABLE_OLLAMA_API are set by the chart itself from
+  # `ollama.enabled: false` above. Re-declaring them here produced:
+  #   "hides previous definition of ENABLE_OLLAMA_API, which may be dropped
+  #    when using apply"
+  # Leave them to the chart -- inference goes to OPENAI_API_BASE_URL instead.
 
 # No ingress - we'll use Tailscale
 ingress:

--- a/k8s/openwebui/postgres.yaml
+++ b/k8s/openwebui/postgres.yaml
@@ -7,6 +7,14 @@ spec:
   instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:16.4
   enableSuperuserAccess: true
+  # Superuser credentials come from a Secret, never from this manifest.
+  # Create it out-of-band (see docs/manual-changes-2026-08-03.md):
+  #   kubectl -n openwebui create secret generic openwebui-db-superuser \
+  #     --type=kubernetes.io/basic-auth \
+  #     --from-literal=username=postgres \
+  #     --from-literal=password="$(openssl rand -base64 36)"
+  superuserSecret:
+    name: openwebui-db-superuser
 
   storage:
     storageClass: longhorn
@@ -26,4 +34,5 @@ spec:
       owner: postgres
       postInitSQL:
         - CREATE EXTENSION IF NOT EXISTS vector;
-        - ALTER USER postgres WITH PASSWORD 'PMy8GF6KuomeWdqYef6FE0F6pKgrVb8vw9jcQrJwBfkiWZD0f5LygsRhdEuNf7lB';
+        # NOTE: do NOT set the superuser password here -- CNPG manages it from
+        # superuserSecret above. A password in this manifest lands in git.

--- a/k8s/tailscale/acl-policy.json
+++ b/k8s/tailscale/acl-policy.json
@@ -1,48 +1,81 @@
 {
-  "// NOTE": "This is an example ACL policy for Tailscale admin console",
-  "// Instructions": "Copy this content to Tailscale admin console → Access Controls",
+  "// NOTE": "Mirror of the live Tailscale ACL policy. Edit in the admin console (Access Controls), then sync here.",
+  "// FORMAT": "The console accepts HuJSON (comments + trailing commas); this file is strict JSON so repo tooling can parse it.",
 
-  "tagOwners": {
-    "tag:k8s-operator": [],
-    "tag:k8s-pedro-ops": ["tag:k8s-operator"],
-    "tag:gpu-inference": []
+  "groups": {
+    "group:personal": [
+      "captainnobody1@gmail.com",
+      "Caleb@bclife.biz",
+      "obrien.colin009@gmail.com",
+      "davidbosnic99@gmail.com"
+    ]
   },
 
-  "grants": [
-    {
-      "src": ["tag:k8s-operator"],
-      "dst": ["tag:k8s-pedro-ops"],
-      "op": "is-owner"
-    }
-  ],
+  "hosts": {
+    "raspberryPi": "100.93.172.103",
+    "pi4": "100.76.13.90",
+    "windows": "100.89.139.55"
+  },
 
   "acls": [
     {
       "action": "accept",
-      "src": ["tag:k8s-pedro-ops"],
-      "dst": ["tag:gpu-inference:*"],
-      "comment": "Allow pedro-ops cluster to connect to GPU inference machine"
-    },
-    {
-      "action": "accept",
-      "src": ["tag:gpu-inference"],
-      "dst": ["tag:k8s-pedro-ops:*"],
-      "comment": "Allow GPU machine to connect back to cluster"
-    },
-    {
-      "action": "accept",
-      "src": ["autogroup:admin"],
-      "dst": ["*:*"],
-      "comment": "Admins can access everything"
+      "users": ["*"],
+      "ports": ["*:*"]
     }
   ],
 
   "ssh": [
     {
+      "action": "check",
+      "src": ["autogroup:members"],
+      "dst": ["autogroup:self"],
+      "users": ["ubuntu", "root", "miriahpeterson", "soypete"],
+      "checkPeriod": "20h"
+    },
+    {
       "action": "accept",
-      "src": ["autogroup:admin"],
-      "dst": ["tag:k8s-pedro-ops", "tag:gpu-inference"],
-      "users": ["root", "autogroup:nonroot"]
+      "src": ["group:personal", "autogroup:members"],
+      "dst": ["tag:k8s"],
+      "users": ["ubuntu", "root", "soypete", "rojuinex"]
+    },
+    {
+      "action": "accept",
+      "src": ["tag:k8s"],
+      "dst": ["tag:k8s"],
+      "users": ["root"]
+    }
+  ],
+
+  "tagOwners": {
+    "tag:prod": ["group:personal"],
+    "tag:production": ["group:personal"],
+    "tag:k8s-operator": ["group:personal", "tag:k8s-operator"],
+    "tag:k8s": ["tag:k8s-operator"]
+  },
+
+  "grants": [
+    {
+      "src": ["*"],
+      "dst": ["tag:k8s-operator"],
+      "ip": ["tcp:443"]
+    }
+  ],
+
+  "autoApprovers": {
+    "services": {
+      "tag:k8s": ["tag:k8s"]
+    }
+  },
+
+  "nodeAttrs": [
+    {
+      "target": ["tag:k8s"],
+      "attr": ["funnel"]
+    },
+    {
+      "target": ["100.71.226.113"],
+      "attr": ["funnel"]
     }
   ]
 }

--- a/k8s/tailscale/openwebui-ingress.yaml
+++ b/k8s/tailscale/openwebui-ingress.yaml
@@ -4,8 +4,10 @@ metadata:
   name: openwebui-tailscale
   namespace: openwebui
   annotations:
+    # The operator applies its own PROXY_TAGS (tag:k8s) to the proxy node.
+    # Do not set tailscale.com/tags here: tag:k8s-pedro-ops and tag:production
+    # were removed from the tailnet, and an unowned tag fails node auth.
     tailscale.com/tailnet-fqdn: ai.tail6fbc5.ts.net
-    tailscale.com/tags: tag:k8s-pedro-ops,tag:production
 spec:
   ingressClassName: tailscale
   defaultBackend:

--- a/scripts/deploy-openwebui.sh
+++ b/scripts/deploy-openwebui.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 #   6. openwebui-db Cluster CR     (kubectl -- CNPG has no chart for a database)
 #   7. pgvector extension
 #   8. OpenWebUI + Redis + Tika + pipelines (helm, upstream chart)
+#   9. Tailscale ingress           (kubectl -- exposes ai.tail6fbc5.ts.net)
 #
 # Idempotent: safe to re-run, and safe to run against a freshly rebuilt cluster.
 # Existing secrets are NOT overwritten, so re-running will not rotate credentials
@@ -32,6 +33,8 @@ NAMESPACE="${OPENWEBUI_NAMESPACE:-openwebui}"
 RELEASE="${OPENWEBUI_RELEASE:-openwebui}"
 VALUES="${REPO_ROOT}/helm/openwebui/values.yaml"
 PG_MANIFEST="${REPO_ROOT}/k8s/openwebui/postgres.yaml"
+INGRESS_MANIFEST="${REPO_ROOT}/k8s/tailscale/openwebui-ingress.yaml"
+INGRESS_FQDN="ai.tail6fbc5.ts.net"
 PG_CLUSTER="openwebui-db"
 PG_SECRET="openwebui-db-superuser"
 APP_SECRET="openwebui-secrets"
@@ -232,17 +235,51 @@ fi
 echo ""
 
 # --- 8. openwebui ----------------------------------------------------------
-echo "[8/8] OpenWebUI (+ Redis, Tika, pipelines)..."
+echo "[8/9] OpenWebUI (+ Redis, Tika, pipelines)..."
 helm upgrade --install "$RELEASE" open-webui/open-webui \
     -n "$NAMESPACE" -f "$VALUES" --wait --timeout 10m >/dev/null
 ok "helm release deployed"
+echo ""
+
+# --- 9. tailscale ingress --------------------------------------------------
+# The chart's own ingress stays disabled (ingress.enabled=false); exposure is
+# via the Tailscale operator, which needs a separate Ingress with
+# ingressClassName: tailscale. Without this the app is ClusterIP-only.
+#
+# Do NOT add a tailscale.com/tags annotation to that manifest -- the operator
+# applies its own PROXY_TAGS, and requesting a tag the tailnet does not own
+# (e.g. the removed tag:k8s-pedro-ops) makes node authentication fail.
+echo "[9/9] Tailscale ingress..."
+kubectl apply -f "$INGRESS_MANIFEST" >/dev/null
+ok "ingress applied"
+
+# The operator provisions a proxy StatefulSet and then writes the FQDN back to
+# the ingress status. Poll for it so the script fails loudly if that stalls.
+INGRESS_NAME="$(kubectl -n "$NAMESPACE" get ingress -o jsonpath='{.items[?(@.spec.ingressClassName=="tailscale")].metadata.name}' 2>/dev/null | awk '{print $1}')"
+ADDR=""
+for _ in $(seq 1 30); do
+    ADDR="$(kubectl -n "$NAMESPACE" get ingress "$INGRESS_NAME" \
+        -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)"
+    [ -n "$ADDR" ] && break
+    sleep 5
+done
+
+if [ -n "$ADDR" ]; then
+    ok "exposed at https://${ADDR}/"
+    if [ "$ADDR" != "$INGRESS_FQDN" ]; then
+        warn "expected ${INGRESS_FQDN} -- a stale tailnet node may still hold that name"
+    fi
+else
+    warn "no address yet; check: kubectl logs -n tailscale deploy/operator"
+fi
 echo ""
 
 echo -e "${GREEN}=== Deployment complete ===${NC}"
 echo ""
 kubectl -n "$NAMESPACE" get pods
 echo ""
-echo "Access (no ingress -- ingress.enabled=false, Tailscale was the intended path):"
+echo "Access:"
+echo "  https://${ADDR:-$INGRESS_FQDN}/"
 echo "  kubectl -n ${NAMESPACE} port-forward svc/${RELEASE}-open-webui 8080:8080"
 echo ""
 echo "NOTE: this cluster has NO backup for ${PG_CLUSTER}. See issue #13."

--- a/scripts/deploy-openwebui.sh
+++ b/scripts/deploy-openwebui.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+set -euo pipefail
+
+# OpenWebUI Deployment
+#
+# Deploys the full OpenWebUI stack, in dependency order:
+#   1. CloudNativePG operator      (helm, upstream chart)
+#   2. openwebui namespace
+#   3. Postgres superuser secret   (generated if absent -- never committed)
+#   4. openwebui-secrets           (app secrets, sourced from 1Password)
+#   5. SeaweedFS buckets           (delegates to setup-seaweedfs-buckets.sh)
+#   6. openwebui-db Cluster CR     (kubectl -- CNPG has no chart for a database)
+#   7. pgvector extension
+#   8. OpenWebUI + Redis + Tika + pipelines (helm, upstream chart)
+#
+# Idempotent: safe to re-run, and safe to run against a freshly rebuilt cluster.
+# Existing secrets are NOT overwritten, so re-running will not rotate credentials
+# out from under a running database.
+#
+# Usage:
+#   ./scripts/deploy-openwebui.sh
+#   SKIP_SECRETS=1 ./scripts/deploy-openwebui.sh   # secrets already exist
+#
+# Prerequisites:
+#   - kubectl with KUBECONFIG set (~/.foundry/kubeconfig)
+#   - helm
+#   - SeaweedFS running (for S3 file storage)
+#   - op (1Password CLI) unless SKIP_SECRETS=1 or the secret already exists
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NAMESPACE="${OPENWEBUI_NAMESPACE:-openwebui}"
+RELEASE="${OPENWEBUI_RELEASE:-openwebui}"
+VALUES="${REPO_ROOT}/helm/openwebui/values.yaml"
+PG_MANIFEST="${REPO_ROOT}/k8s/openwebui/postgres.yaml"
+PG_CLUSTER="openwebui-db"
+PG_SECRET="openwebui-db-superuser"
+APP_SECRET="openwebui-secrets"
+SKIP_SECRETS="${SKIP_SECRETS:-0}"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info()  { echo -e "      $1"; }
+ok()    { echo -e "      ${GREEN}✓ $1${NC}"; }
+warn()  { echo -e "      ${YELLOW}! $1${NC}"; }
+fail()  { echo -e "      ${RED}✗ $1${NC}"; }
+
+echo "=== OpenWebUI Deployment ==="
+echo ""
+
+# --- preflight -------------------------------------------------------------
+for bin in kubectl helm; do
+    command -v "$bin" >/dev/null || { fail "$bin not found in PATH"; exit 1; }
+done
+
+if ! kubectl get nodes &>/dev/null; then
+    fail "Cannot access Kubernetes cluster"
+    echo "  export KUBECONFIG=~/.foundry/kubeconfig"
+    exit 1
+fi
+
+[ -f "$VALUES" ] || { fail "missing $VALUES"; exit 1; }
+[ -f "$PG_MANIFEST" ] || { fail "missing $PG_MANIFEST"; exit 1; }
+
+# --- 1. CNPG operator ------------------------------------------------------
+echo "[1/8] CloudNativePG operator..."
+helm repo add cnpg https://cloudnative-pg.github.io/charts >/dev/null 2>&1 || true
+helm repo add open-webui https://helm.openwebui.com >/dev/null 2>&1 || true
+helm repo update >/dev/null 2>&1
+
+if kubectl get crd clusters.postgresql.cnpg.io &>/dev/null; then
+    ok "CRDs already present"
+else
+    info "installing..."
+fi
+helm upgrade --install cnpg cnpg/cloudnative-pg \
+    -n cnpg-system --create-namespace --wait --timeout 5m >/dev/null
+ok "operator ready"
+echo ""
+
+# --- 2. namespace ----------------------------------------------------------
+echo "[2/8] Namespace ${NAMESPACE}..."
+kubectl create ns "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+ok "namespace ready"
+echo ""
+
+# --- 3. postgres superuser secret -----------------------------------------
+echo "[3/8] Postgres superuser secret..."
+if kubectl -n "$NAMESPACE" get secret "$PG_SECRET" &>/dev/null; then
+    ok "${PG_SECRET} exists (not overwriting -- rotating would break the running DB)"
+else
+    PGPW="$(openssl rand -base64 36 | tr -d '\n/+=' | head -c 40)"
+    kubectl -n "$NAMESPACE" create secret generic "$PG_SECRET" \
+        --type=kubernetes.io/basic-auth \
+        --from-literal=username=postgres \
+        --from-literal=password="$PGPW" >/dev/null
+    ok "${PG_SECRET} created with a generated password"
+    warn "store it in 1Password: kubectl -n ${NAMESPACE} get secret ${PG_SECRET} -o jsonpath='{.data.password}' | base64 -d"
+fi
+echo ""
+
+# --- 4. app secrets --------------------------------------------------------
+echo "[4/8] Application secrets..."
+if kubectl -n "$NAMESPACE" get secret "$APP_SECRET" &>/dev/null; then
+    ok "${APP_SECRET} exists"
+    # A stale DATABASE_URL (left over from a previous cluster) causes the same
+    # "password authentication failed" crashloop as a mismatched DB password,
+    # so verify it carries the current superuser password.
+    if kubectl -n "$NAMESPACE" get secret "$PG_SECRET" &>/dev/null; then
+        _pw="$(kubectl -n "$NAMESPACE" get secret "$PG_SECRET" -o jsonpath='{.data.password}' | base64 -d)"
+        _url="$(kubectl -n "$NAMESPACE" get secret "$APP_SECRET" -o jsonpath='{.data.DATABASE_URL}' | base64 -d)"
+        if [ -n "$_url" ] && ! printf '%s' "$_url" | grep -qF "$_pw"; then
+            warn "DATABASE_URL does not contain the current superuser password -- refreshing it"
+            kubectl -n "$NAMESPACE" patch secret "$APP_SECRET" --type=merge -p \
+                "{\"data\":{\"DATABASE_URL\":\"$(printf 'postgresql://postgres:%s@%s-rw:5432/openwebui' "$_pw" "$PG_CLUSTER" | base64 | tr -d '\n')\"}}" >/dev/null
+            ok "DATABASE_URL refreshed"
+        fi
+    fi
+elif [ "$SKIP_SECRETS" = "1" ]; then
+    warn "${APP_SECRET} missing and SKIP_SECRETS=1 -- OpenWebUI will not start"
+else
+    # S3 credentials live in the Foundry stack config, not in a k8s Secret --
+    # SeaweedFS receives them through chart values at install time.
+    # NOTE: this is the SAME key pair Loki and Velero use, so OpenWebUI can read
+    # and delete their objects. Splitting these into per-app least-privilege
+    # credentials is tracked in the audit doc; do not treat this as good practice.
+    STACK="${FOUNDRY_STACK:-$HOME/.foundry/stack.yaml}"
+    if [ ! -f "$STACK" ]; then
+        fail "cannot read S3 credentials: ${STACK} not found"
+        echo ""
+        echo "  Create ${APP_SECRET} manually, then re-run:"
+        echo "    kubectl -n ${NAMESPACE} create secret generic ${APP_SECRET} \\"
+        echo "      --from-literal=WEBUI_SECRET_KEY=\$(openssl rand -hex 32) \\"
+        echo "      --from-literal=DATABASE_URL=postgresql://postgres:<pw>@${PG_CLUSTER}-rw:5432/openwebui \\"
+        echo "      --from-literal=AWS_ACCESS_KEY_ID=... \\"
+        echo "      --from-literal=AWS_SECRET_ACCESS_KEY=..."
+        exit 1
+    fi
+    info "sourcing S3 credentials from ${STACK}..."
+    S3_KEY="$(awk '/^[[:space:]]*s3_access_key:/ {print $2; exit}' "$STACK")"
+    S3_SEC="$(awk '/^[[:space:]]*s3_secret_key:/ {print $2; exit}' "$STACK")"
+    if [ -z "$S3_KEY" ] || [ -z "$S3_SEC" ]; then
+        fail "could not parse s3_access_key / s3_secret_key from ${STACK}"
+        exit 1
+    fi
+    PGPW="$(kubectl -n "$NAMESPACE" get secret "$PG_SECRET" -o jsonpath='{.data.password}' | base64 -d)"
+    kubectl -n "$NAMESPACE" create secret generic "$APP_SECRET" \
+        --from-literal=WEBUI_SECRET_KEY="$(openssl rand -hex 32)" \
+        --from-literal=DATABASE_URL="postgresql://postgres:${PGPW}@${PG_CLUSTER}-rw:5432/openwebui" \
+        --from-literal=AWS_ACCESS_KEY_ID="$S3_KEY" \
+        --from-literal=AWS_SECRET_ACCESS_KEY="$S3_SEC" >/dev/null
+    ok "${APP_SECRET} created"
+    warn "WEBUI_SECRET_KEY was generated -- save it to 1Password, it invalidates sessions if lost"
+fi
+echo ""
+
+# --- 5. S3 buckets ---------------------------------------------------------
+echo "[5/8] SeaweedFS buckets..."
+if kubectl -n seaweedfs get pod seaweedfs-filer-0 &>/dev/null; then
+    # Surface only the per-bucket result lines; the child script's trailing
+    # remediation notes are not useful inline here.
+    "${REPO_ROOT}/scripts/setup-seaweedfs-buckets.sh" openwebui openwebui-pg 2>&1 \
+        | grep -E '(created|already exists|still missing|bucket\(s\) present)' \
+        | sed 's/^ */      /'
+else
+    warn "SeaweedFS not found -- skipping bucket creation (file storage will fail)"
+fi
+echo ""
+
+# --- 6. postgres cluster ---------------------------------------------------
+echo "[6/8] Postgres cluster ${PG_CLUSTER}..."
+kubectl apply -f "$PG_MANIFEST" >/dev/null
+info "waiting for cluster to become ready (up to 5m)..."
+for _ in $(seq 1 60); do
+    READY="$(kubectl -n "$NAMESPACE" get cluster "$PG_CLUSTER" -o jsonpath='{.status.readyInstances}' 2>/dev/null || echo 0)"
+    [ "${READY:-0}" -ge 1 ] && break
+    sleep 5
+done
+if [ "${READY:-0}" -ge 1 ]; then
+    ok "cluster healthy (${READY} ready instance(s))"
+else
+    fail "cluster did not become ready"
+    kubectl -n "$NAMESPACE" get cluster "$PG_CLUSTER" 2>&1 | sed 's/^/      /'
+    exit 1
+fi
+echo ""
+
+# --- 7. pgvector + superuser password reconcile ----------------------------
+# Two first-bootstrap gotchas, both idempotent to repair:
+#
+#  a) postInitSQL only runs on FIRST bootstrap, so a cluster that already
+#     existed (or was recovered from backup) can be missing pgvector.
+#
+#  b) If the cluster bootstrapped BEFORE superuserSecret existed, CNPG keeps the
+#     password it generated at bootstrap and does not retroactively adopt the
+#     Secret. OpenWebUI then fails with:
+#       FATAL: password authentication failed for user "postgres"
+#     Step 3 runs before step 6 so a clean install is fine, but an
+#     already-bootstrapped cluster needs the password aligned to the Secret.
+echo "[7/8] pgvector extension + superuser password..."
+PRIMARY="$(kubectl -n "$NAMESPACE" get cluster "$PG_CLUSTER" -o jsonpath='{.status.currentPrimary}')"
+
+PGPW="$(kubectl -n "$NAMESPACE" get secret "$PG_SECRET" -o jsonpath='{.data.password}' | base64 -d)"
+if kubectl -n "$NAMESPACE" exec "$PRIMARY" -c postgres -- \
+        env PGPASSWORD="$PGPW" psql -h 127.0.0.1 -U postgres -d openwebui -tAc "select 1;" >/dev/null 2>&1; then
+    ok "superuser password matches ${PG_SECRET}"
+else
+    warn "database password does not match ${PG_SECRET} -- aligning it"
+    kubectl -n "$NAMESPACE" exec "$PRIMARY" -c postgres -- \
+        psql -U postgres -d openwebui -c "ALTER USER postgres WITH PASSWORD '${PGPW}';" >/dev/null
+    if kubectl -n "$NAMESPACE" exec "$PRIMARY" -c postgres -- \
+            env PGPASSWORD="$PGPW" psql -h 127.0.0.1 -U postgres -d openwebui -tAc "select 1;" >/dev/null 2>&1; then
+        ok "superuser password aligned"
+    else
+        fail "could not align superuser password"
+        exit 1
+    fi
+fi
+
+kubectl -n "$NAMESPACE" exec "$PRIMARY" -c postgres -- \
+    psql -U postgres -d openwebui -c "CREATE EXTENSION IF NOT EXISTS vector;" >/dev/null 2>&1
+VEC="$(kubectl -n "$NAMESPACE" exec "$PRIMARY" -c postgres -- \
+    psql -U postgres -d openwebui -tAc "select extversion from pg_extension where extname='vector';" 2>/dev/null | tr -d '\r')"
+if [ -n "$VEC" ]; then
+    ok "pgvector ${VEC} installed"
+else
+    fail "pgvector not installed -- VECTOR_DB=pgvector will fail"
+    exit 1
+fi
+echo ""
+
+# --- 8. openwebui ----------------------------------------------------------
+echo "[8/8] OpenWebUI (+ Redis, Tika, pipelines)..."
+helm upgrade --install "$RELEASE" open-webui/open-webui \
+    -n "$NAMESPACE" -f "$VALUES" --wait --timeout 10m >/dev/null
+ok "helm release deployed"
+echo ""
+
+echo -e "${GREEN}=== Deployment complete ===${NC}"
+echo ""
+kubectl -n "$NAMESPACE" get pods
+echo ""
+echo "Access (no ingress -- ingress.enabled=false, Tailscale was the intended path):"
+echo "  kubectl -n ${NAMESPACE} port-forward svc/${RELEASE}-open-webui 8080:8080"
+echo ""
+echo "NOTE: this cluster has NO backup for ${PG_CLUSTER}. See issue #13."

--- a/scripts/phase3-deploy-foundry.sh
+++ b/scripts/phase3-deploy-foundry.sh
@@ -71,8 +71,10 @@ echo ""
 
 # Get kubeconfig
 echo "[5/5] Configuring kubectl access..."
-foundry kubeconfig > ~/.kube/pedro-ops-config
-export KUBECONFIG=~/.kube/pedro-ops-config
+# foundry maintains its own kubeconfig; do not redirect to a second copy that
+# will silently go stale (see docs/manual-changes-2026-08-03.md).
+foundry kubeconfig >/dev/null 2>&1 || true
+export KUBECONFIG=~/.foundry/kubeconfig
 
 echo "Verifying cluster access..."
 kubectl get nodes -o wide
@@ -85,13 +87,13 @@ echo ""
 echo -e "${GREEN}=== Foundry Stack Deployment Complete ===${NC}"
 echo ""
 echo "Cluster Information:"
-echo "  Kubeconfig: ~/.kube/pedro-ops-config"
+echo "  Kubeconfig: ~/.foundry/kubeconfig"
 echo "  API Endpoint: https://100.81.89.100:6443"
 echo "  Domain: soypetetech.local"
 echo ""
 echo -e "${YELLOW}Next Steps:${NC}"
 echo "1. Verify all components:"
-echo "   export KUBECONFIG=~/.kube/pedro-ops-config"
+echo "   export KUBECONFIG=~/.foundry/kubeconfig"
 echo "   kubectl get pods -A"
 echo ""
 echo "2. Get Grafana password:"

--- a/scripts/phase4-install-tailscale.sh
+++ b/scripts/phase4-install-tailscale.sh
@@ -16,7 +16,7 @@ NC='\033[0m'
 if ! kubectl get nodes &>/dev/null; then
     echo -e "${RED}Cannot access Kubernetes cluster!${NC}"
     echo "Make sure kubeconfig is set:"
-    echo "  export KUBECONFIG=~/.kube/pedro-ops-config"
+    echo "  export KUBECONFIG=~/.foundry/kubeconfig"
     exit 1
 fi
 

--- a/scripts/setup-cluster.sh
+++ b/scripts/setup-cluster.sh
@@ -272,7 +272,7 @@ fi
 
 echo ""
 print_step "Verifying cluster access..."
-export KUBECONFIG=~/.kube/pedro-ops-config
+export KUBECONFIG=~/.foundry/kubeconfig
 kubectl get nodes -o wide
 echo ""
 
@@ -283,7 +283,7 @@ echo "✓ kubectl configured"
 echo ""
 
 print_step "Cluster Information:"
-echo "  Kubeconfig: ~/.kube/pedro-ops-config"
+echo "  Kubeconfig: ~/.foundry/kubeconfig"
 echo "  API Endpoint: https://100.81.89.100:6443"
 echo "  Domain: soypetetech.local"
 echo ""
@@ -431,8 +431,8 @@ echo ""
 
 # Export kubeconfig reminder
 echo "To use kubectl, run:"
-echo "  export KUBECONFIG=~/.kube/pedro-ops-config"
+echo "  export KUBECONFIG=~/.foundry/kubeconfig"
 echo ""
 echo "Or add to your shell profile:"
-echo "  echo 'export KUBECONFIG=~/.kube/pedro-ops-config' >> ~/.bashrc"
+echo "  echo 'export KUBECONFIG=~/.foundry/kubeconfig' >> ~/.bashrc"
 echo ""

--- a/scripts/setup-seaweedfs-buckets.sh
+++ b/scripts/setup-seaweedfs-buckets.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+set -euo pipefail
+
+# SeaweedFS Bucket Provisioning
+#
+# Creates the S3 buckets the cluster depends on. Idempotent: existing buckets
+# are left alone, so this is safe to re-run and safe to run during a rebuild.
+#
+# Why this exists: the 2026-08-03 rebuild left SeaweedFS with filer metadata
+# referencing volumes that no longer existed, and with buckets missing entirely.
+# That single fault crashlooped Loki and broke Velero. Bucket creation was a
+# manual step nobody had written down.
+#
+# Usage:
+#   ./scripts/setup-seaweedfs-buckets.sh            # create the default set
+#   ./scripts/setup-seaweedfs-buckets.sh foo bar    # create specific buckets
+
+NAMESPACE="${SEAWEEDFS_NAMESPACE:-seaweedfs}"
+FILER_POD="${SEAWEEDFS_FILER_POD:-seaweedfs-filer-0}"
+
+# Buckets required by the stack. Keep in sync with:
+#   loki       -> foundry stack.yaml components.loki.s3_bucket
+#   velero     -> foundry stack.yaml components.velero (BSL objectStorage.bucket)
+#   openwebui  -> helm/openwebui/values.yaml persistence.s3.bucket
+#   openwebui-pg -> CNPG barman-cloud ObjectStore (see issue #13)
+DEFAULT_BUCKETS=(loki velero openwebui openwebui-pg)
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+if [ "$#" -gt 0 ]; then
+    BUCKETS=("$@")
+else
+    BUCKETS=("${DEFAULT_BUCKETS[@]}")
+fi
+
+echo "=== SeaweedFS Bucket Provisioning ==="
+echo ""
+
+if ! kubectl get nodes &>/dev/null; then
+    echo -e "${RED}Cannot access Kubernetes cluster!${NC}"
+    echo "Make sure kubeconfig is set:"
+    echo "  export KUBECONFIG=~/.foundry/kubeconfig"
+    exit 1
+fi
+
+if ! kubectl -n "$NAMESPACE" get pod "$FILER_POD" &>/dev/null; then
+    echo -e "${RED}✗ Filer pod ${NAMESPACE}/${FILER_POD} not found${NC}"
+    echo "  Is SeaweedFS deployed? kubectl -n ${NAMESPACE} get pods"
+    exit 1
+fi
+
+# Run a command in `weed shell` on the filer pod.
+weed_shell() {
+    kubectl -n "$NAMESPACE" exec "$FILER_POD" --request-timeout=60s -- \
+        sh -c "echo '$1' | weed shell" 2>/dev/null
+}
+
+# weed shell prints banner lines and its ">" prompt to the same stream as
+# results, and the first result shares a line with the prompt ("> \tloki\tsize:0").
+# Match on the trailing "size:" marker and strip any leading prompt/whitespace,
+# rather than a bare grep which would false-positive on the command echo.
+list_buckets() {
+    weed_shell "s3.bucket.list" \
+        | sed -n 's/.*[[:space:]>]\{1,\}\([A-Za-z0-9._-]\{1,\}\)[[:space:]]\{1,\}size:.*/\1/p'
+}
+
+echo "[1/3] Reading existing buckets..."
+EXISTING="$(list_buckets || true)"
+if [ -n "$EXISTING" ]; then
+    echo "$EXISTING" | sed 's/^/      /'
+else
+    echo "      (none)"
+fi
+echo ""
+
+echo "[2/3] Creating missing buckets..."
+CREATED=0
+for bucket in "${BUCKETS[@]}"; do
+    if echo "$EXISTING" | grep -qx "$bucket"; then
+        echo -e "      ${YELLOW}= ${bucket}${NC} already exists, skipping"
+    else
+        weed_shell "s3.bucket.create -name ${bucket}" >/dev/null
+        echo -e "      ${GREEN}+ ${bucket}${NC} created"
+        CREATED=$((CREATED + 1))
+    fi
+done
+echo ""
+
+echo "[3/3] Verifying..."
+FINAL="$(list_buckets || true)"
+MISSING=0
+for bucket in "${BUCKETS[@]}"; do
+    if ! echo "$FINAL" | grep -qx "$bucket"; then
+        echo -e "      ${RED}✗ ${bucket} still missing${NC}"
+        MISSING=$((MISSING + 1))
+    fi
+done
+
+if [ "$MISSING" -gt 0 ]; then
+    echo ""
+    echo -e "${RED}✗ ${MISSING} bucket(s) could not be created${NC}"
+    exit 1
+fi
+
+echo -e "      ${GREEN}✓ all ${#BUCKETS[@]} bucket(s) present${NC}"
+echo ""
+echo -e "${GREEN}=== Done (${CREATED} created) ===${NC}"
+echo ""
+echo "NOTE: a bucket existing does not prove S3 reads work. If the filer holds"
+echo "metadata for volumes that no longer exist, GETs return HTTP 500 while the"
+echo "bucket still lists fine. Verify with:"
+echo "  kubectl -n ${NAMESPACE} logs deploy/seaweedfs-s3 --tail=50"
+echo ""
+echo "If you see 'volume N not found for fileId', the filer has orphaned entries"
+echo "from a previous cluster whose volume data is gone. The referenced objects are"
+echo "unrecoverable; only dead metadata remains. Clear a affected bucket with:"
+echo ""
+echo "  # DESTRUCTIVE -- deletes all objects in the bucket. Confirm the data is"
+echo "  # genuinely orphaned first (fs.meta.cat shows a volumeId that does not"
+echo "  # exist in 'weed shell -> volume.list')."
+echo "  kubectl -n ${NAMESPACE} exec ${FILER_POD} -- \\"
+echo "    sh -c \"echo 's3.bucket.delete -name <bucket>' | weed shell\""
+echo "  ./scripts/setup-seaweedfs-buckets.sh <bucket>   # recreate empty"

--- a/scripts/sync-openwebui-secrets-to-openbao.sh
+++ b/scripts/sync-openwebui-secrets-to-openbao.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+set -euo pipefail
+
+# Sync OpenWebUI cluster secrets into OpenBAO
+#
+# WHY: WEBUI_SECRET_KEY is generated at deploy time and currently lives ONLY in
+# the Kubernetes Secret. If the cluster is rebuilt it is lost, and losing it
+# invalidates every existing OpenWebUI session. The Postgres superuser password
+# has the same problem. These are cluster secrets, so OpenBAO is their home.
+#
+# This reads the live Kubernetes secrets and writes them to OpenBAO. It does NOT
+# read anything back out or print secret values.
+#
+# OpenBAO runs OUTSIDE the k8s cluster (host-level Foundry component), currently
+# at http://100.70.90.12:8200. It survived the 2026-08-03 rebuild.
+#
+# Usage:
+#   ./scripts/sync-openwebui-secrets-to-openbao.sh            # write
+#   DRY_RUN=1 ./scripts/sync-openwebui-secrets-to-openbao.sh  # show paths only
+#
+# Auth: uses $VAULT_TOKEN if set, otherwise the root token from
+#       ~/.foundry/openbao-keys/<cluster>/keys.json
+
+VAULT_ADDR="${VAULT_ADDR:-http://100.70.90.12:8200}"
+KEYS_FILE="${OPENBAO_KEYS_FILE:-$HOME/.foundry/openbao-keys/test/keys.json}"
+MOUNT="${OPENBAO_MOUNT:-foundry-core}"
+NAMESPACE="${OPENWEBUI_NAMESPACE:-openwebui}"
+DRY_RUN="${DRY_RUN:-0}"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo "=== Sync OpenWebUI secrets -> OpenBAO ==="
+echo ""
+echo "  OpenBAO: ${VAULT_ADDR}"
+echo "  Mount:   ${MOUNT}"
+echo ""
+
+if ! kubectl get nodes &>/dev/null; then
+    echo -e "${RED}Cannot access Kubernetes cluster${NC}"
+    echo "  export KUBECONFIG=~/.foundry/kubeconfig"
+    exit 1
+fi
+
+# --- auth -----------------------------------------------------------------
+if [ -z "${VAULT_TOKEN:-}" ]; then
+    if [ ! -f "$KEYS_FILE" ]; then
+        echo -e "${RED}No \$VAULT_TOKEN and no keys file at ${KEYS_FILE}${NC}"
+        exit 1
+    fi
+    VAULT_TOKEN="$(python3 -c "import json;print(json.load(open('${KEYS_FILE}'))['root_token'])")"
+    echo -e "      ${YELLOW}! using root token from ${KEYS_FILE}${NC}"
+    echo -e "      ${YELLOW}  (prefer a scoped token via \$VAULT_TOKEN for routine use)${NC}"
+fi
+
+HEALTH="$(curl -s -m 10 -o /dev/null -w '%{http_code}' "${VAULT_ADDR}/v1/sys/health" || echo 000)"
+if [ "$HEALTH" != "200" ]; then
+    echo -e "${RED}OpenBAO not healthy at ${VAULT_ADDR} (HTTP ${HEALTH})${NC}"
+    echo "  If the address changed, re-run with:"
+    echo "    VAULT_ADDR=http://<host>:8200 $0"
+    exit 1
+fi
+echo -e "      ${GREEN}✓ OpenBAO reachable and unsealed${NC}"
+echo ""
+
+# --- helpers --------------------------------------------------------------
+# Read one key out of a k8s secret. Returns empty if absent.
+k8s_secret_value() {
+    kubectl -n "$NAMESPACE" get secret "$1" -o jsonpath="{.data.$2}" 2>/dev/null | base64 -d 2>/dev/null || true
+}
+
+# Write a KV-v2 secret. Values are passed via stdin as JSON so they never
+# appear in the process list.
+bao_put() {
+    local path="$1" json="$2"
+    if [ "$DRY_RUN" = "1" ]; then
+        echo -e "      ${YELLOW}[dry-run]${NC} would write ${MOUNT}/${path} keys: $(printf '%s' "$json" | python3 -c 'import json,sys;print(",".join(json.load(sys.stdin)["data"].keys()))')"
+        return
+    fi
+    local code
+    code="$(printf '%s' "$json" | curl -s -m 15 -o /dev/null -w '%{http_code}' \
+        -H "X-Vault-Token: ${VAULT_TOKEN}" \
+        -X POST --data-binary @- "${VAULT_ADDR}/v1/${MOUNT}/data/${path}")"
+    if [ "$code" = "200" ] || [ "$code" = "204" ]; then
+        echo -e "      ${GREEN}✓${NC} ${MOUNT}/${path}"
+    else
+        echo -e "      ${RED}✗${NC} ${MOUNT}/${path} (HTTP ${code})"
+        return 1
+    fi
+}
+
+# Build KV-v2 payload from key=value pairs without interpolating into a shell
+# string (avoids quoting bugs and keeps values out of argv).
+build_payload() {
+    python3 -c '
+import json,sys
+data = {}
+for line in sys.stdin.read().split("\0"):
+    if not line: continue
+    k, _, v = line.partition("=")
+    if v: data[k] = v
+print(json.dumps({"data": data}))
+'
+}
+
+# --- openwebui app secrets ------------------------------------------------
+echo "[1/2] openwebui app secrets..."
+WEBUI_KEY="$(k8s_secret_value openwebui-secrets WEBUI_SECRET_KEY)"
+DB_URL="$(k8s_secret_value openwebui-secrets DATABASE_URL)"
+S3_ID="$(k8s_secret_value openwebui-secrets AWS_ACCESS_KEY_ID)"
+S3_SECRET="$(k8s_secret_value openwebui-secrets AWS_SECRET_ACCESS_KEY)"
+
+if [ -z "$WEBUI_KEY" ]; then
+    echo -e "      ${RED}✗ openwebui-secrets/WEBUI_SECRET_KEY not found in ns ${NAMESPACE}${NC}"
+    exit 1
+fi
+
+printf 'WEBUI_SECRET_KEY=%s\0DATABASE_URL=%s\0AWS_ACCESS_KEY_ID=%s\0AWS_SECRET_ACCESS_KEY=%s\0' \
+    "$WEBUI_KEY" "$DB_URL" "$S3_ID" "$S3_SECRET" \
+    | build_payload | { read -r payload; bao_put "apps/openwebui" "$payload"; }
+echo ""
+
+# --- postgres superuser ---------------------------------------------------
+echo "[2/2] openwebui-db superuser..."
+PG_USER="$(k8s_secret_value openwebui-db-superuser username)"
+PG_PASS="$(k8s_secret_value openwebui-db-superuser password)"
+
+if [ -z "$PG_PASS" ]; then
+    echo -e "      ${YELLOW}! openwebui-db-superuser not found, skipping${NC}"
+else
+    printf 'username=%s\0password=%s\0' "$PG_USER" "$PG_PASS" \
+        | build_payload | { read -r payload; bao_put "apps/openwebui-db" "$payload"; }
+fi
+echo ""
+
+echo -e "${GREEN}=== Done ===${NC}"
+echo ""
+echo "Verify (prints key names only, not values):"
+echo "  curl -s -H \"X-Vault-Token: \$VAULT_TOKEN\" \\"
+echo "    ${VAULT_ADDR}/v1/${MOUNT}/data/apps/openwebui | python3 -c \\"
+echo "    'import json,sys;print(list(json.load(sys.stdin)[\"data\"][\"data\"].keys()))'"
+echo ""
+echo "NOTE: these secrets are also still in 1Password-less generated form. After"
+echo "verifying, treat OpenBAO as the source of truth and re-run this after any"
+echo "credential rotation."

--- a/scripts/validate-storage.sh
+++ b/scripts/validate-storage.sh
@@ -20,7 +20,7 @@ NC='\033[0m'
 if ! kubectl get nodes &>/dev/null; then
     echo -e "${RED}Cannot access Kubernetes cluster!${NC}"
     echo "Make sure kubeconfig is set:"
-    echo "  export KUBECONFIG=~/.kube/pedro-ops-config"
+    echo "  export KUBECONFIG=~/.foundry/kubeconfig"
     exit 1
 fi
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,84 @@
+apiVersion: skaffold/v4beta11
+kind: Config
+metadata:
+  name: pedro-ops
+
+# Declarative deploy definition for the cluster's application stack.
+#
+# SCOPE / HONESTY NOTE: this repo builds no images -- every workload here uses an
+# upstream chart or a prebuilt image from the Zot registry. So there is no
+# `build:` stanza and no file-watch dev loop worth running. Skaffold is used
+# purely as a declarative "deploy these releases in this order" manifest, which
+# duplicates scripts/deploy-openwebui.sh in a form other tools can consume.
+#
+# The scripts remain the source of truth for a rebuild, because they do things
+# Skaffold cannot express: generating secrets, creating S3 buckets, waiting on
+# the CNPG Cluster CR, installing pgvector, and reconciling the superuser
+# password. Prefer:
+#
+#   ./scripts/deploy-openwebui.sh
+#
+# Skaffold has NOT been validated against this cluster (skaffold is not
+# installed on the admin machine as of 2026-08-03). Treat the profiles below as
+# a starting point to verify, not a proven path.
+#
+# Usage once skaffold is installed:
+#   skaffold deploy -p openwebui       # requires secrets + buckets to exist
+#   skaffold deploy -p infra
+
+profiles:
+  # ---------------------------------------------------------------------------
+  # Cluster prerequisites that application charts depend on.
+  # ---------------------------------------------------------------------------
+  - name: infra
+    deploy:
+      helm:
+        releases:
+          - name: cnpg
+            repo: https://cloudnative-pg.github.io/charts
+            remoteChart: cloudnative-pg
+            namespace: cnpg-system
+            createNamespace: true
+            wait: true
+
+  # ---------------------------------------------------------------------------
+  # OpenWebUI stack. Redis, Tika and pipelines are subcharts of open-webui and
+  # are enabled through helm/openwebui/values.yaml -- they are not separate
+  # releases.
+  #
+  # PREREQUISITES not handled here (use scripts/deploy-openwebui.sh):
+  #   - secrets: openwebui-db-superuser, openwebui-secrets
+  #   - S3 buckets: openwebui, openwebui-pg
+  #   - the openwebui-db CNPG Cluster CR + pgvector extension
+  # ---------------------------------------------------------------------------
+  - name: openwebui
+    manifests:
+      rawYaml:
+        - k8s/openwebui/postgres.yaml
+    deploy:
+      helm:
+        releases:
+          - name: openwebui
+            repo: https://helm.openwebui.com
+            remoteChart: open-webui
+            namespace: openwebui
+            createNamespace: true
+            valuesFiles:
+              - helm/openwebui/values.yaml
+            wait: true
+
+  # ---------------------------------------------------------------------------
+  # Embedding server. Public image, no registry dependency, so this one is
+  # genuinely standalone.
+  # ---------------------------------------------------------------------------
+  - name: embed
+    deploy:
+      helm:
+        releases:
+          - name: pedro-embed-server
+            chartPath: helm/pedro-embed-server
+            namespace: chatbot
+            createNamespace: true
+            valuesFiles:
+              - helm/pedro-embed-server/values.yaml
+            wait: true


### PR DESCRIPTION
Deploys OpenWebUI after the 2026-08-03 cluster rebuild, fixes the bugs found while
doing it, and captures every step in scripts so a future rebuild does not depend on
undocumented manual work.

## Bugs fixed

Four of these were latent in the repo, not caused by the rebuild:

| Bug | Detail |
|---|---|
| **Redis never deployed** | `redis.enabled: false` while `websocket.manager: redis` — websockets pointed at a Redis that was never created. |
| **S3 port wrong since `7d9f718`** | `values.yaml` used `seaweedfs-s3:8332`; the live service port is **8333**. This never worked. Now uses the FQDN. |
| **Plaintext Postgres password in git** | `postgres.yaml:29` set the superuser password in `postInitSQL`. Replaced with `superuserSecret`; password rotated. |
| **Duplicate env vars** | `OLLAMA_BASE_URLS` / `ENABLE_OLLAMA_API` in `extraEnvVars` collided with values the chart sets from `ollama.enabled: false` (`"hides previous definition … may be dropped"`). |

Two first-bootstrap traps that cost real debugging time and are now handled automatically:

- **`postInitSQL` only runs on first bootstrap**, so `CREATE EXTENSION vector` never applied. The image *does* ship pgvector (`vector 0.8.0`) — it just needed running.
- **CNPG does not retroactively adopt `superuserSecret`** for an already-bootstrapped cluster. It keeps its bootstrap password, and OpenWebUI crashloops with `FATAL: password authentication failed for user "postgres"`. The deploy script now detects and repairs both cases.

## New automation

| Script | Purpose |
|---|---|
| `scripts/deploy-openwebui.sh` | End-to-end deploy in dependency order. **Verified idempotent** — a second run exits 0 and skips every existing resource. |
| `scripts/setup-seaweedfs-buckets.sh` | Idempotent S3 bucket provisioning (`loki`, `velero`, `openwebui`, `openwebui-pg`). Bucket creation was previously an unwritten manual step. |
| `scripts/sync-openwebui-secrets-to-openbao.sh` | Pushes cluster secrets to OpenBAO. `WEBUI_SECRET_KEY` is generated at deploy time and otherwise lives **only** in a k8s Secret — losing it invalidates every session. Supports `DRY_RUN=1`; never prints values. |
| `skaffold.yaml` | Declarative deploy profiles. **Unvalidated** — skaffold is not installed on the admin machine and this repo builds no images. Marked as such; the scripts remain the source of truth. |

## Correction: OpenBAO was not destroyed

The audit doc originally reported OpenBAO as lost in the rebuild. **That was wrong**, and §1.5 is corrected in this PR.

OpenBAO is a *host-level* Foundry component (no k8s PVC by design) and survived at `100.70.90.12:8200` — initialized, unsealed, `foundry-core/` KV mount intact, stored root token still authenticating. The mistake was inferring destruction from an absent PVC; it never had one because it never ran in Kubernetes. **No re-initialization is needed.**

## Result

```
openwebui-db-1 / -2              1/1  Running   # CNPG primary + replica
openwebui-open-webui             1/1  Running
openwebui-open-webui-redis       1/1  Running
openwebui-pipelines              1/1  Running
openwebui-tika                   1/1  Running
```

Migrations ran (`Seeded 380 new config defaults`); the app serves HTTP 200.

## Known gaps (not addressed here)

- **No ingress.** `k8s/tailscale/openwebui-ingress.yaml` for `ai.tail6fbc5.ts.net` already existed and is correct, but the Tailscale operator's stored OAuth credentials return **401** from Tailscale's own token endpoint — expired/revoked. CRDs and the `tailscale` IngressClass are installed; the operator is scaled to 0 pending new credentials. Access is `port-forward` until then.
- **No backups** for `openwebui-db` — tracked in #13.
- **Shared S3 credentials.** OpenWebUI reuses the one key pair Loki, Velero and SeaweedFS share, so any component can delete another's objects. Read from `~/.foundry/stack.yaml` because no k8s Secret holds them. Splitting into per-app least-privilege keys is still TODO.
- **Loki remains down** — the SeaweedFS filer holds orphaned metadata for volumes that no longer exist. Clearing it needs a destructive bucket delete; exact commands are in `docs/manual-changes-2026-08-03.md` §3a.

## Test plan

- [x] `scripts/deploy-openwebui.sh` run against the live cluster — all 8 steps pass
- [x] Re-run to confirm idempotency — exit 0, no unintended changes
- [x] `setup-seaweedfs-buckets.sh` re-run — correctly skips existing buckets
- [x] `sync-openwebui-secrets-to-openbao.sh` dry-run — connects, resolves correct paths
- [x] OpenWebUI verified serving HTTP 200 with migrations applied
- [ ] `skaffold.yaml` — **not tested**, skaffold not installed
- [ ] Secret sync **not executed** (root-token write; left for the repo owner)
