### PR TITLE
Automate OpenWebUI deployment and fix Flannel routing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,6 +35,21 @@ Pedro Ops is a production-ready 3-node Kubernetes cluster built with Foundry CLI
 
 > **Note:** The cluster uses Tailscale for remote access. The Kubeconfig and node joins use the control plane's Tailscale IP (100.81.89.62), not the VIP (10.0.0.11), since the VIP is not accessible over Tailscale network.
 
+### Network planes
+
+The cluster deliberately uses separate networks for separate purposes:
+
+| Plane | Addresses | Purpose |
+|---|---|---|
+| Physical LAN | `192.168.1.185`, `.97`, `.253` | K3s node addresses and Flannel VXLAN underlay |
+| Pod network | `10.42.0.0/16` | Kubernetes pod-to-pod traffic carried by Flannel |
+| Service network | `10.43.0.0/16` | Kubernetes virtual Service IPs, including kube-dns |
+| Tailscale | `100.x.x.x` | Remote administration and selected service exposure |
+| API VIP | `10.0.0.11` | Kubernetes API endpoint only; never a Flannel endpoint |
+
+Kubernetes Service names (`*.svc.cluster.local`) are resolved by CoreDNS. The
+Foundry PowerDNS component and Tailscale MagicDNS serve different namespaces.
+
 ## Software Stack
 
 ### Core Kubernetes Layer

--- a/docs/incidents/2026-08-05-flannel-vip-openwebui.md
+++ b/docs/incidents/2026-08-05-flannel-vip-openwebui.md
@@ -1,0 +1,47 @@
+# Flannel API VIP misdirection and OpenWebUI outage — 2026-08-05
+
+## Impact
+
+OpenWebUI remained probe-healthy but authenticated requests intermittently
+returned HTTP 500. WebSockets repeatedly failed to connect to Redis. The UI also
+continued to report v0.10.2 after Helm reported app version 0.11.0.
+
+## Root causes
+
+1. blue1 advertised the Kubernetes API VIP `10.0.0.11` as its Flannel public
+   endpoint. Workers advertised their physical LAN addresses. Cross-node pod
+   traffic destined for blue1 therefore failed, including DNS requests from an
+   OpenWebUI pod on refurb to CoreDNS on blue1.
+2. OpenWebUI used the mutable image tag `latest` with `IfNotPresent`. Helm had
+   upgraded to chart 16.0.0/appVersion 0.11.0, but the node reused a cached
+   v0.10.2 image.
+3. PostgreSQL was configured only as `PGVECTOR_DB_URL`; the primary
+   `DATABASE_URL` was absent. Users, chats, and settings therefore lived in a
+   SQLite database on the pod's ephemeral `EmptyDir` and disappeared whenever
+   the pod was replaced.
+
+The unhealthy Foundry PowerDNS recursor observed at the same time was separate
+from Kubernetes `*.svc.cluster.local` resolution.
+
+## Resolution
+
+- Pinned blue1 to `node-ip: 192.168.1.185` and `flannel-iface: enp1s0`.
+- Corrected the stale blue1 and blue2 LAN addresses in the cluster scripts.
+- Pinned Helm chart `16.0.0` and OpenWebUI image `v0.11.0`.
+- Connected both the primary application database and pgvector store to the
+  existing PostgreSQL Secret.
+- Replaced stale Whisper variables with the live Moonshine STT Service and its
+  OpenAI-compatible `small-streaming` model.
+- Restarted K3s on blue1 and verified all Flannel endpoints use `192.168.1.x`.
+- Verified DNS and TCP connectivity from OpenWebUI to Redis and PostgreSQL by
+  their Kubernetes Service names before rolling out OpenWebUI.
+
+## Prevention
+
+- Do not allow `10.0.0.11` to be selected as a node or Flannel endpoint; it is
+  only the Kubernetes API VIP.
+- Keep immutable application image tags and explicit Helm chart versions.
+- Verify that `DATABASE_URL` is present in the rendered application container;
+  `PGVECTOR_DB_URL` alone does not persist users, chats, or settings.
+- When Kubernetes Service DNS fails, compare every node's `InternalIP` with its
+  `flannel.alpha.coreos.com/public-ip` annotation before restarting CoreDNS.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -69,7 +69,7 @@ kubectl port-forward -n longhorn-system svc/longhorn-frontend 7000:80
 ### OpenWebUI
 ```bash
 helm repo update
-helm upgrade openwebui open-webui/open-webui -n openwebui
+helm upgrade openwebui open-webui/open-webui --version 16.0.0 -n openwebui
 ```
 
 ### PostgreSQL (CloudNativePG)
@@ -194,6 +194,11 @@ OpenWebUI runs in the `openwebui` namespace with the following components:
 Database: CloudNativePG PostgreSQL cluster with pgvector in `openwebui` namespace.
 Storage: Longhorn volumes on Worker-1 2TB drive.
 
+`DATABASE_URL` stores primary OpenWebUI state (users, chats, settings, and API
+keys). `PGVECTOR_DB_URL` stores vector data. Both are sourced from the
+`openwebui-secrets` Secret; setting only `PGVECTOR_DB_URL` leaves primary state
+in ephemeral SQLite.
+
 ### Deploy/Update OpenWebUI
 
 ```bash
@@ -201,7 +206,7 @@ Storage: Longhorn volumes on Worker-1 2TB drive.
 vim helm/openwebui/values.yaml
 
 # Deploy/upgrade
-helm upgrade openwebui open-webui/open-webui -n openwebui -f helm/openwebui/values.yaml
+helm upgrade openwebui open-webui/open-webui --version 16.0.0 -n openwebui -f helm/openwebui/values.yaml
 
 # Verify deployment
 kubectl get pods -n openwebui
@@ -225,7 +230,7 @@ kubectl get cluster -n openwebui
 
 ```bash
 # Redis is deployed via Helm chart sub-chart
-helm upgrade openwebui open-webui/open-webui -n openwebui -f helm/openwebui/values.yaml
+helm upgrade openwebui open-webui/open-webui --version 16.0.0 -n openwebui -f helm/openwebui/values.yaml
 ```
 
 ### Connect to PostgreSQL

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -259,12 +259,33 @@ kubectl exec -n <namespace> <pod-name> -- cat /etc/hosts
 **Diagnosis:**
 
 ```bash
+# Identify where the affected workload and CoreDNS are running
+kubectl get pods -n <namespace> -o wide
+kubectl get pods -n kube-system -l k8s-app=kube-dns -o wide
+
 # Test DNS resolution
 kubectl run test --image=nicolaka/netshoot -it --rm -- nslookup kubernetes.default.svc.cluster.local
 
 # Test connectivity to service
 kubectl run test --image=nicolaka/netshoot -it --rm -- curl http://my-service.my-namespace.svc.cluster.local
+
+# Confirm that the Service has ready backends
+kubectl get service,endpoints,endpointslices -n <namespace> <service-name> -o wide
 ```
+
+From an existing application pod, compare its DNS path with the Service IP. A
+DNS-name failure combined with a successful direct Service-IP connection means
+the application and backend are reachable and the fault is on the DNS path:
+
+```bash
+kubectl exec -n <namespace> <pod> -- getent hosts <service>.<namespace>.svc.cluster.local
+kubectl exec -n <namespace> <pod> -- nc -vz <service-cluster-ip> <port>
+```
+
+If the application and backend share a node but CoreDNS is on another node,
+same-node success plus DNS failure strongly indicates broken cross-node CNI
+traffic. Do not work around this by committing a Service IP: ClusterIPs and pod
+endpoints are implementation details that can change on a rebuild.
 
 **Solutions:**
 
@@ -287,8 +308,31 @@ kubectl run test --image=nicolaka/netshoot -it --rm -- curl http://my-service.my
 
 4. **Verify CNI (Flannel):**
    ```bash
-   kubectl get pods -n kube-system -l app=flannel
+   kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{" node="}{range .status.addresses[?(@.type=="InternalIP")]}{.address}{end}{" flannel="}{.metadata.annotations.flannel\.alpha\.coreos\.com/public-ip}{"\n"}{end}'
    ```
+
+   All Flannel endpoints must use the physical LAN:
+
+   ```text
+   blue1  node=192.168.1.185 flannel=192.168.1.185
+   blue2  node=192.168.1.97  flannel=192.168.1.97
+   refurb node=192.168.1.253 flannel=192.168.1.253
+   ```
+
+   The API VIP `10.0.0.11` must never appear as a Flannel endpoint. On
+   2026-08-05, blue1 advertised that VIP and broke cross-node pod traffic. DNS
+   appeared unhealthy because CoreDNS ran on blue1 while affected workloads ran
+   on refurb. Direct same-node Service IP connections continued to work.
+
+5. **Distinguish the DNS layers:**
+
+   - CoreDNS resolves Kubernetes names such as `*.svc.cluster.local`.
+   - PowerDNS is the Foundry `dns` component for managed/internal zones.
+   - Tailscale MagicDNS resolves tailnet machine and `*.ts.net` names.
+
+   An unhealthy `foundry stack status` DNS recursor does not by itself explain
+   failures to resolve Kubernetes Service names. Check the Flannel path to
+   CoreDNS as shown above.
 
 ### Ingress Not Working
 

--- a/helm/openwebui/values.yaml
+++ b/helm/openwebui/values.yaml
@@ -2,7 +2,9 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/open-webui/open-webui
-  tag: latest
+  # Keep this immutable. `latest` + IfNotPresent reused a cached v0.10.2 image
+  # even after Helm upgraded to a chart whose appVersion was v0.11.0.
+  tag: v0.11.0
   pullPolicy: IfNotPresent
 
 service:
@@ -60,6 +62,13 @@ extraEnvVars:
       secretKeyRef:
         name: openwebui-secrets
         key: WEBUI_SECRET_KEY
+  # Primary application database: users, chats, settings, API keys, etc.
+  # Without this, OpenWebUI falls back to SQLite in the pod's ephemeral data volume.
+  - name: DATABASE_URL
+    valueFrom:
+      secretKeyRef:
+        name: openwebui-secrets
+        key: DATABASE_URL
   - name: OPENAI_API_BASE_URL
     value: "http://100.121.229.114:8000/v1"
   - name: OPENAI_API_KEY
@@ -71,7 +80,6 @@ extraEnvVars:
       secretKeyRef:
         name: openwebui-secrets
         key: DATABASE_URL
-        optional: true
   - name: ENABLE_DB_MIGRATIONS
     value: "true"
   - name: DEFAULT_LOCALE

--- a/scripts/deploy-openwebui.sh
+++ b/scripts/deploy-openwebui.sh
@@ -31,6 +31,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 NAMESPACE="${OPENWEBUI_NAMESPACE:-openwebui}"
 RELEASE="${OPENWEBUI_RELEASE:-openwebui}"
+OPENWEBUI_CHART_VERSION="${OPENWEBUI_CHART_VERSION:-16.0.0}"
 VALUES="${REPO_ROOT}/helm/openwebui/values.yaml"
 PG_MANIFEST="${REPO_ROOT}/k8s/openwebui/postgres.yaml"
 INGRESS_MANIFEST="${REPO_ROOT}/k8s/tailscale/openwebui-ingress.yaml"
@@ -237,6 +238,7 @@ echo ""
 # --- 8. openwebui ----------------------------------------------------------
 echo "[8/9] OpenWebUI (+ Redis, Tika, pipelines)..."
 helm upgrade --install "$RELEASE" open-webui/open-webui \
+    --version "$OPENWEBUI_CHART_VERSION" \
     -n "$NAMESPACE" -f "$VALUES" --wait --timeout 10m >/dev/null
 ok "helm release deployed"
 echo ""

--- a/scripts/k8s/apply-cluster-config.sh
+++ b/scripts/k8s/apply-cluster-config.sh
@@ -4,13 +4,12 @@
 # Run this after setting up a new node or if CoreDNS/registry config is lost.
 #
 # Cluster nodes (Tailscale IPs):
-#   blue1  (control plane + ZOT registry): 100.81.89.62  (LAN: 192.168.1.128)
-#   blue2  (worker):                       100.125.196.1 (LAN: 192.168.1.11)
+#   blue1  (control plane + ZOT registry): 100.81.89.62  (LAN: 192.168.1.185)
+#   blue2  (worker):                       100.125.196.1 (LAN: 192.168.1.97)
 #   refurb (worker):                       100.70.90.12  (LAN: 192.168.1.253)
 #
-# Note: blue1 also has 100.118.20.111 (pedro-ops-api Tailscale device) on enp1s0.
-# The k3s node-ip must be set to 192.168.1.128 to prevent flannel from binding to
-# 100.118.20.111 as the VXLAN VTEP, which breaks cross-node pod networking.
+# blue1 also owns the API VIP 10.0.0.11. Pinning flannel-iface prevents that VIP
+# from being advertised as its VXLAN endpoint.
 
 set -euo pipefail
 
@@ -28,9 +27,7 @@ echo "    (requires SSH access as root to blue1, blue2, refurb)"
 
 # blue1 (control plane)
 echo "    -> blue1 (100.81.89.62)"
-ssh root@100.81.89.62 "mkdir -p /etc/rancher/k3s && cat > /etc/rancher/k3s/config.yaml <<'EOF'
-node-ip: 192.168.1.128
-EOF"
+scp "$SCRIPT_DIR/k3s-config-blue1.yaml" "root@100.81.89.62:/etc/rancher/k3s/config.yaml"
 scp "$SCRIPT_DIR/registries.yaml" "root@100.81.89.62:/etc/rancher/k3s/registries.yaml"
 ssh root@100.81.89.62 "systemctl restart k3s"
 echo "    <- blue1 done (cluster will be unavailable ~30s)"
@@ -38,18 +35,14 @@ sleep 35
 
 # blue2 (worker)
 echo "    -> blue2 (100.125.196.1)"
-ssh root@100.125.196.1 "mkdir -p /etc/rancher/k3s && cat > /etc/rancher/k3s/config.yaml <<'EOF'
-node-ip: 192.168.1.11
-EOF"
+scp "$SCRIPT_DIR/k3s-config-blue2.yaml" "root@100.125.196.1:/etc/rancher/k3s/config.yaml"
 scp "$SCRIPT_DIR/registries.yaml" "root@100.125.196.1:/etc/rancher/k3s/registries.yaml"
 ssh root@100.125.196.1 "systemctl restart k3s-agent"
 echo "    <- blue2 done"
 
 # refurb (worker)
 echo "    -> refurb (100.70.90.12)"
-ssh root@100.70.90.12 "mkdir -p /etc/rancher/k3s && cat > /etc/rancher/k3s/config.yaml <<'EOF'
-node-ip: 192.168.1.253
-EOF"
+scp "$SCRIPT_DIR/k3s-config-refurb.yaml" "root@100.70.90.12:/etc/rancher/k3s/config.yaml"
 scp "$SCRIPT_DIR/registries.yaml" "root@100.70.90.12:/etc/rancher/k3s/registries.yaml"
 ssh root@100.70.90.12 "systemctl restart k3s-agent"
 echo "    <- refurb done"

--- a/scripts/k8s/k3s-config-blue1.yaml
+++ b/scripts/k8s/k3s-config-blue1.yaml
@@ -2,8 +2,9 @@
 # Place at: /etc/rancher/k3s/config.yaml
 # Then restart: systemctl restart k3s
 #
-# IMPORTANT: node-ip must be the LAN IP, NOT 100.118.20.111 (pedro-ops-api Tailscale subnet IP).
-# If k3s picks 100.118.20.111 as node-ip, flannel binds its VXLAN VTEP to that IP which
-# routes through Tailscale from worker nodes, breaking cross-node pod networking.
+# Keep both the Kubernetes node address and Flannel's VXLAN endpoint on the
+# physical LAN. blue1 also owns the API VIP (10.0.0.11), which Flannel selected
+# automatically during the 2026-08 rebuild and broke cross-node pod traffic.
 
-node-ip: 192.168.1.128
+node-ip: 192.168.1.185
+flannel-iface: enp1s0

--- a/scripts/k8s/k3s-config-blue2.yaml
+++ b/scripts/k8s/k3s-config-blue2.yaml
@@ -2,4 +2,4 @@
 # Place at: /etc/rancher/k3s/config.yaml
 # Then restart: systemctl restart k3s-agent
 
-node-ip: 192.168.1.11
+node-ip: 192.168.1.97

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -61,6 +61,7 @@ profiles:
           - name: openwebui
             repo: https://helm.openwebui.com
             remoteChart: open-webui
+            version: 16.0.0
             namespace: openwebui
             createNamespace: true
             valuesFiles:


### PR DESCRIPTION
## What changed

- automate the OpenWebUI, PostgreSQL, Redis, Tika, pipelines, and SeaweedFS deployment flow
- pin the OpenWebUI Helm chart to `16.0.0` and the application image to immutable `v0.11.0`
- correct blue1 and blue2 LAN node addresses and pin blue1 Flannel to `enp1s0`
- replace inline remote K3s config generation with the checked-in node config files
- document the 2026-08-05 Flannel/API-VIP incident, network planes, and practical DNS/CNI debugging steps

## Why

blue1 advertised the Kubernetes API VIP `10.0.0.11` as its Flannel endpoint while the workers advertised their physical LAN addresses. Cross-node pod traffic to blue1 failed, including OpenWebUI DNS requests to CoreDNS. OpenWebUI consequently timed out talking to Redis and returned HTTP 500 for authenticated requests.

Separately, `image.tag: latest` with `IfNotPresent` reused a cached OpenWebUI `v0.10.2` image even though Helm chart metadata reported app version `0.11.0`.

## Impact

Flannel now uses the physical `192.168.1.x` LAN on every node, Kubernetes Service DNS works across nodes, and OpenWebUI runs `v0.11.0` with deterministic chart/image versions.

## Validation

- all nodes Ready and advertising matching LAN node/Flannel addresses
- OpenWebUI pod resolved and connected to Redis and PostgreSQL by `*.svc.cluster.local` name
- Helm release revision 9 is `deployed`, chart `16.0.0`, app `0.11.0`
- OpenWebUI deployment is 1/1 Ready
- `/health` returned HTTP 200
- `/api/version` returned `0.11.0`
- Web UI login verified manually
- `bash -n` passed for changed shell scripts
- `git diff --check` passed

## Follow-up

The Foundry PowerDNS recursor remains a separate issue from Kubernetes CoreDNS/Flannel and should be diagnosed in the Foundry repository.