### PR TITLE
Correct node IPs and document pedro-agents deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,15 @@ This is an Infrastructure as Code (IaC) repository containing:
 ## Cluster Architecture
 
 ### Node Topology
-- **Control Plane**: 100.81.89.62 (K8s control plane + infrastructure services)
-- **Worker 1**: 100.70.90.12 (workloads + 2TB storage backend)
-- **Worker 2**: 100.125.196.1 (workloads)
-- **Virtual IP**: 100.81.89.100 (K8s API endpoint)
+
+| Node | Role | Tailscale | LAN |
+|------|------|-----------|-----|
+| blue1 | control plane | 100.81.89.62 | 192.168.1.185 |
+| blue2 | worker | 100.125.196.1 | 192.168.1.97 |
+| refurb | worker (2TB storage backend) | 100.70.90.12 | 192.168.1.253 |
+
+The API endpoint is `https://192.168.1.185:6443` (blue1). The Tailscale VIP
+`100.81.89.100` is **deprecated** — do not point kubeconfigs at it.
 
 ### Storage Strategy
 - 2TB drive on Worker-1 mounted at `/data/persistent-storage/`
@@ -71,6 +76,12 @@ foundry logs
 ```bash
 # Set kubeconfig
 export KUBECONFIG=~/.foundry/kubeconfig
+
+# If every kubectl command fails with "the server could not find the
+# requested resource" -- including `kubectl version` and `kubectl get --raw
+# /healthz` -- the kubeconfig has no current-context selected. The error is
+# misleading; the cluster is fine. Select the context:
+kubectl --kubeconfig ~/.foundry/kubeconfig config use-context default
 
 # Cluster operations
 kubectl get nodes

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ A production-ready 3-node Kubernetes cluster deployed with [Foundry CLI](https:/
 
 ### Node Topology
 
-| Role | IP Address | Purpose |
-|------|------------|---------|
-| Control Plane | 100.81.89.62 | K8s control plane + infrastructure services |
-| Worker 1 | 100.70.90.12 | Workloads + 2TB storage backend |
-| Worker 2 | 100.125.196.1 | Workloads |
-| Virtual IP | 100.81.89.100 | K8s API endpoint |
+| Node | Role | Tailscale | LAN | Purpose |
+|------|------|-----------|-----|---------|
+| blue1 | Control Plane | 100.81.89.62 | 192.168.1.185 | K8s control plane + infrastructure services (Zot, OpenBao) |
+| refurb | Worker | 100.70.90.12 | 192.168.1.253 | Workloads + 2TB storage backend |
+| blue2 | Worker | 100.125.196.1 | 192.168.1.97 | Workloads |
+
+The K8s API endpoint is `https://192.168.1.185:6443` (blue1). The old
+Tailscale VIP `100.81.89.100` is **deprecated** — do not use it.
 
 ### Storage Layout
 
@@ -160,6 +162,17 @@ kubectl apply -k k8s/overlays/production
 # Install Helm charts
 helm install my-app ./helm/my-app -n default
 ```
+
+Applications deployed from other repos:
+
+- **pedro-agents** (Reddit monitor, suggest, social, CFP) — see
+  [docs/pedro-agents-deployment.md](docs/pedro-agents-deployment.md).
+  Chart lives in [`pedro-bots`](https://github.com/Soypete/pedro-bots).
+
+> **Note:** image pulls from Zot currently fail on all nodes because
+> `/etc/rancher/k3s/registries.yaml` is missing — containerd speaks HTTPS to
+> a plain-HTTP registry. See
+> [docs/zot-registry-guide.md](docs/zot-registry-guide.md).
 
 ### Monitor Cluster
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,12 +57,12 @@ Foundry PowerDNS component and Tailscale MagicDNS serve different namespaces.
 ```
 ┌─────────────────────────────────────────────────────────┐
 │                    K3s (Kubernetes)                      │
-│                      v1.28.x+k3s1                        │
+│                      v1.36.2+k3s1                        │
 ├─────────────────────────────────────────────────────────┤
 │  • Lightweight Kubernetes distribution                  │
-│  • Control Plane: 100.81.89.62                          │
-│  • Workers: 100.70.90.12, 100.125.196.1                 │
-│  • API Server: https://100.81.89.100:6443               │
+│  • Control Plane: blue1  100.81.89.62                    │
+│  • Workers: refurb 100.70.90.12, blue2 100.125.196.1     │
+│  • API Server: https://192.168.1.185:6443                │
 └─────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/cluster-state.md
+++ b/docs/cluster-state.md
@@ -40,7 +40,7 @@ Last updated: 2025-07-21
 | projectcontour | Active | Ingress controller |
 | seaweedfs | Active | S3-compatible storage |
 | velero | Active | Backup system |
-| redditwatch | Active | Reddit monitoring agent |
+| redditwatch | Active | Pedro agents: Reddit monitor, suggest, social, CFP (Helm release `pedro-agents`) |
 
 ### Deleted Namespaces
 

--- a/docs/pedro-agents-deployment.md
+++ b/docs/pedro-agents-deployment.md
@@ -1,0 +1,91 @@
+# Pedro Agents Deployment
+
+LLM-powered agents that monitor Reddit, suggest topics, post to social, and
+watch for conference CFPs. Source and chart live in
+[`pedro-bots`](https://github.com/Soypete/pedro-bots), not this repo.
+
+- **Namespace**: `redditwatch`
+- **Helm release**: `pedro-agents` (chart `charts/pedro-agents` in pedro-bots)
+- **Image**: `100.81.89.62:5000/redditwatch:latest`
+- **Deployed**: 2026-08-06
+
+## What runs
+
+Four CronJobs, all times UTC:
+
+| CronJob | Schedule | Purpose |
+|---------|----------|---------|
+| `pedro-agents-monitor` | `0 14,19,0 * * *` | Fetch + classify Reddit posts, digest to Discord |
+| `pedro-agents-suggest` | `0 15 * * 1` | Weekly subreddit/keyword suggestions |
+| `pedro-agents-social` | `0 14 * * *` | Social posting |
+| `pedro-agents-cfp` | `0 16 * * 2` | Search for conference CFPs, digest to Discord |
+
+Schedules are Mountain Time expressed in UTC, so they shift by an hour
+between MDT and MST. The comments in `values.yaml` note the alternates.
+
+## Deploying
+
+```bash
+cd ~/code/pedro/pedro-bots
+helm upgrade --install pedro-agents charts/pedro-agents -n redditwatch
+```
+
+Use `--reset-values` if a previous upgrade set overrides with `--set`;
+otherwise Helm carries those forward and the chart defaults appear to be
+ignored.
+
+## Dependencies
+
+- **Postgres** — `postgres.chatbot.svc.cluster.local`, database
+  `pedro_agentware`. Tables are `rw_topics`, `rw_classifications`, `rw_cfps`
+  in the `public` schema. Migrations live in `pedro-bots/migrations/` and can
+  be applied with:
+  ```bash
+  kubectl exec -i -n chatbot postgres -- \
+    psql -U postgres -d pedro_agentware -v ON_ERROR_STOP=1 -f - < migrations/00N_x.sql
+  ```
+- **llama.cpp** — `http://100.121.229.114:8000/v1` (Tailscale GPU box).
+  Note **port 8000**, not 8080.
+- **Secrets** — the `redditwatch-secrets` Secret in the namespace, holding
+  the Reddit, Discord, Supabase, and `POSTGRES_URL` values.
+
+## Secrets: Secret vs OpenBao
+
+The chart supports both, selected by `vault.enabled`:
+
+- `vault.enabled=false` (**default**) — reads the existing
+  `redditwatch-secrets` Secret via `envFrom`.
+- `vault.enabled=true` — OpenBao agent injection writes
+  `/vault/secrets/{reddit,discord,supabase}`, which the container sources
+  before starting.
+
+Injection defaults to off because the `redditwatch` OpenBao role has not
+been verified. The injector is running (`openbao-injector-agent-injector`
+in the `openbao` namespace) and the pattern works for other apps, but an
+unrecognised role leaves pods hanging on init rather than failing fast.
+Verify the role exists before flipping this on.
+
+## Known issue: image pulls
+
+`imagePullPolicy` is `IfNotPresent` rather than `Always` because
+`/etc/rancher/k3s/registries.yaml` is not applied to the nodes, so
+containerd tries HTTPS against Zot's plain-HTTP endpoint and every pull
+fails. See [zot-registry-guide.md](zot-registry-guide.md).
+
+Consequence: **pushing a new image does not update the cluster.** Nodes keep
+using their cached layer. Until `registries.yaml` is applied, deploying new
+application code requires fixing the node config first.
+
+## Checking on it
+
+```bash
+kubectl get cronjobs -n redditwatch
+kubectl get jobs -n redditwatch --sort-by=.metadata.creationTimestamp | tail
+kubectl logs -n redditwatch -l job-name=<job> --tail=50
+
+# Trigger a run by hand
+kubectl create job -n redditwatch manual-cfp --from=cronjob/pedro-agents-cfp
+```
+
+CFP runs are slow — the LLM call grows with each fetched page, and a full
+5-iteration run takes roughly 20 minutes. `activeDeadlineSeconds` is 3600.

--- a/docs/zot-registry-guide.md
+++ b/docs/zot-registry-guide.md
@@ -195,9 +195,17 @@ ssh blue1 "sudo systemctl restart k3s"
 ```
 
 ### Node Hostnames
-- **blue1**: 100.81.89.62 / 192.168.1.128 (control plane)
-- **blue2**: 100.70.90.12 / 192.168.1.11 (worker)
-- **refurb**: 100.125.196.1 / 192.168.1.253 (worker)
+
+Verified against `tailscale status` and `kubectl get nodes -o wide` on 2026-08-06:
+
+| Node | Tailscale | LAN | Role |
+|------|-----------|-----|------|
+| blue1 | 100.81.89.62 | 192.168.1.185 | control plane |
+| blue2 | 100.125.196.1 | 192.168.1.97 | worker |
+| refurb | 100.70.90.12 | 192.168.1.253 | worker |
+
+Zot itself runs on **blue1** and is reachable at `100.81.89.62:5000` and
+`192.168.1.185:5000`. Nothing listens on port 5000 on blue2 or refurb.
 
 ## Troubleshooting
 
@@ -208,10 +216,28 @@ The K3s nodes need the insecure registry configured. See [K3s Node Configuration
 After applying `registries.yaml` to each node, restart K3s:
 ```bash
 # Control plane
-ssh root@100.81.89.62 "systemctl restart k3s"
+ssh root@100.81.89.62 "systemctl restart k3s"        # blue1
 # Workers
-ssh root@100.70.90.12 "systemctl restart k3s-agent"
-ssh root@100.125.196.1 "systemctl restart k3s-agent"
+ssh root@100.125.196.1 "systemctl restart k3s-agent" # blue2
+ssh root@100.70.90.12 "systemctl restart k3s-agent"  # refurb
+```
+
+**This affects every node, including blue1.** Zot running locally does not
+help: containerd still resolves `100.81.89.62:5000` over HTTPS and fails
+before it considers the local cache.
+
+**Workaround when you cannot restart K3s** — set `imagePullPolicy: IfNotPresent`.
+Pods then use the cached image and schedule normally. With the default
+`Always`, *every* pull fails on *every* node, so a workload whose image is
+already cached still cannot start. Note that new pushes will not be picked
+up until `registries.yaml` is in place, so the cluster keeps running the
+stale image.
+
+Check whether a node has an image cached:
+```bash
+kubectl get nodes -o json | jq -r '
+  .items[] | .metadata.name as $n |
+  (.status.images[]?.names[]? | select(contains("<repo>"))) | "\($n) \(.)"'
 ```
 
 ### Image Tag Not Found


### PR DESCRIPTION
Doc corrections found while deploying the pedro-agents Helm release to the cluster.

## The node IPs were wrong

`docs/zot-registry-guide.md` had the Tailscale IPs for blue2 and refurb **swapped**, and blue1's LAN IP was wrong. Verified against `tailscale status` and `kubectl get nodes -o wide`:

| Node | Tailscale | LAN | Role |
|------|-----------|-----|------|
| blue1 | 100.81.89.62 | 192.168.1.185 | control plane |
| blue2 | 100.125.196.1 | 192.168.1.97 | worker |
| refurb | 100.70.90.12 | 192.168.1.253 | worker |

The guide previously said blue2 was `100.70.90.12 / 192.168.1.11` and blue1 was `192.168.1.128`. `docs/architecture.md` and `docs/cluster-state.md` already had it right — the Zot guide was the outlier, which matters because it's the doc you follow while SSH'ing into nodes to restart k3s.

Also confirmed Zot itself runs on **blue1**; nothing listens on `:5000` on blue2 or refurb.

## Deprecated VIP

Dropped `100.81.89.100` from `README.md`, `CLAUDE.md`, and the architecture diagram — the API endpoint is `192.168.1.185:6443`. Left the historical references in the dated audit/manual-changes docs alone. Also corrected the k3s version in the diagram (1.28.x → 1.36.2, per `kubectl get nodes`).

## Kubeconfig failure mode

Added a note to `CLAUDE.md`. When `~/.foundry/kubeconfig` has no `current-context` selected, **every** kubectl call — including `kubectl version` and `kubectl get --raw /healthz` — fails with:

```
Error from server (NotFound): the server could not find the requested resource
```

That reads as a dead cluster, but the apiserver is fine and returns a normal `401` to unauthenticated curl. Fix is `kubectl config use-context default`. Worth writing down because the error points nowhere near the cause.

## Registry troubleshooting

Expanded the HTTP/HTTPS section with two things that weren't obvious:

- It affects **every node, including blue1**. Zot running locally doesn't help — containerd resolves the registry over HTTPS and fails before consulting the local cache.
- **`imagePullPolicy: IfNotPresent` is the workaround** when you can't restart k3s. With the default `Always`, every pull fails on every node, so even a workload whose image is already cached won't start. The caveat is that new pushes are then ignored, so the cluster keeps running a stale image.

## New doc

`docs/pedro-agents-deployment.md` covers the Helm release now running in the `redditwatch` namespace: the four cronjobs and schedules, the Postgres/llama.cpp/secret dependencies, the Secret-vs-OpenBao toggle and why injection defaults to off, and the image-pull caveat above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CHWwoWCcoR5piymfxa6pp