### PR TITLE
feat(pedrogpt): serve two models via llama.cpp router mode

### DIFF
--- a/docs/blog/qwen38-beats-spark-cluster.md
+++ b/docs/blog/qwen38-beats-spark-cluster.md
@@ -181,6 +181,19 @@ His pelican-riding-a-bicycle SVG took 21 minutes at the default setting — 22,2
 
 The fix was one line in the preset: `chat-template-kwargs = {"reasoning_effort": "medium"}`. But I would have shipped the "empty response" bug into production if I had not caught it.
 
+You can also override it per-request in the `/v1/chat/completions` body. llama.cpp accepts a `chat_template_kwargs` field that gets merged into the Jinja template context:
+
+```json
+{
+  "model": "qwen3.8-27b",
+  "messages": [{"role": "user", "content": "rename this function"}],
+  "chat_template_kwargs": {"reasoning_effort": "low"},
+  "max_tokens": 512
+}
+```
+
+This is how you would build a client that uses `medium` for normal edits and `xhigh` for architecture questions without restarting the server. The preset INI sets the default; the request body overrides it.
+
 ### 2. Two models do not fit on one GPU, and that is fine
 
 Qwen3.8-27B at UD-Q4_K_XL is 17.6 GB of weights. My other model (Qwen3.6-27B-MTP) is 17.9 GB. Together that is 35.5 GB of weights before a single byte of KV cache. The card has 32.6 GB. They do not both fit. Not close.

--- a/docs/blog/qwen38-beats-spark-cluster.md
+++ b/docs/blog/qwen38-beats-spark-cluster.md
@@ -1,0 +1,238 @@
+# A 27B model on one 5090 that beats my two-Spark cluster. And Opus 4.
+
+*Follow-up to [I finally replaced Claude Code](./replaced-claude-code.md). Numbers current as of 2026-08-20.*
+
+Last post I wrote about getting MiniMax 2.5 running across two DGX Sparks with Ray + vLLM, and how that finally let me replace Claude Code. The stack worked. The code it wrote was good. I was happy.
+
+Then Qwen3.8-27B came out, and I put it on the RTX 5090 under my desk.
+
+And the 5090 started beating the cluster.
+
+Not on every metric. Not in every condition. But on the metric that actually matters for a coding agent — tokens per second while I'm watching it write code — a single 32GB consumer card is doing **75 tok/s** while my two-node Spark cluster is doing **27**.
+
+That is not a rounding error. That is 2.8x.
+
+---
+
+## What I Added
+
+I did not replace the Spark cluster. I added a second backend.
+
+The 5090 box (pedrogpt) was already running llama.cpp with Qwen3.6-27B-MTP for other work. llama.cpp has a router mode that lets one `llama-server` process serve multiple models by spawning a child per model on demand. I added a section to the preset:
+
+```ini
+[qwen3.8-27b]
+model     = /opt/models/qwen3.8-27b/Qwen3.8-27B-UD-Q4_K_XL.gguf
+ctx-size  = 262144
+```
+
+That's it. The section name is the API id. My OpenCode config now has two backends and I pick per session:
+
+```
+-a http://pedrogpt:8000/v1,qwen3.8-27b
+-b http://100.87.122.109:8000/v1,QuantTrio/MiniMax-M2.5-AWQ
+```
+
+No new hardware. No new cluster. One INI section and a 17.6 GB download.
+
+---
+
+## Why Qwen3.8-27B Specifically
+
+I was not looking for a model. I was looking for a reason to use the 5090 for coding instead of just inference experiments.
+
+Qwen3.8-27B gave me things I did not have with the Spark setup:
+
+**It is fast enough that the wait disappears.** At 75 tok/s, a 200-token response takes about 2.6 seconds. I stop watching. I go do something else and come back to a finished diff. With MiniMax at 27 tok/s, that same response takes 7 seconds, and I am still staring at the cursor. Small difference in isolation. Over a session of twenty edits, it is the difference between "the agent is working" and "I am waiting on the agent."
+
+For context: Simon Willison is getting 15-30 tok/s from this same model on a DGX Spark via LM Studio. My 5090 does 75. The 5090 has 1.8 TB/s of GDDR7 memory bandwidth. The Spark does not. That is the whole game for a dense model — it is a memory bandwidth problem, not a compute problem.
+
+**It has a 262k context window, and it is affordable because of the architecture.** This is the part that surprised me when I read the model card. Qwen3.8 has 64 layers, but only 16 of them use full attention. The other 48 use Gated DeltaNet — a linear attention mechanism that does not carry a growing KV cache. So the KV cache is 1/4 the size you would expect for a 64-layer model. At 262k tokens with q8_0 quantized K/V, that is about 8.6 GB of KV cache against a ~15 GB budget. It fits. The full native window, not a quantized compromise.
+
+The Spark cluster runs MiniMax at 120k. For most PRs that is fine. But when I am working across services, 262k means I do not have to curate what goes in the prompt. And the window is extensible to 1M with RoPE scaling if I ever need it.
+
+**It is a reasoning model that I can dial down.** Qwen3.8 thinks before it answers. By default it thinks at maximum effort (`xhigh`), which is great for hard problems and terrible for "rename this variable." Simon Willison asked it to "draw an SVG of a circle" at the default setting. It spent several minutes reasoning about Bauhaus aesthetics and produced an animated geometric study with a rotating dashed ring. I set mine to `medium` for day-to-day work. The `reasoning_effort` knob is per-request, so I can push it to `xhigh` when I want it to actually reason through an architecture decision, and drop it to `low` for mechanical refactors. MiniMax does not have this. It either thinks or it does not.
+
+**It is a vision model.** This is not a text-only model with a bolted-on image encoder. It is natively multimodal — images and video. I have not wired that into my coding workflow yet, but the fact that the same model that writes my code can also look at a screenshot of a UI bug and tell me what is wrong means I do not need a second model for that.
+
+**It is built for agents.** The model card calls out "Developer Role Support" specifically for agentic tools, and the tool calling was improved in this release to handle nested objects better. That matters because my workflow is not "chat with a model." It is "model reads files, edits files, runs tests, opens a PR." The tool-calling reliability is the difference between an agent that works and one that hallucinates a file path.
+
+---
+
+## Live Metrics from Prometheus
+
+I have both backends scraped into Prometheus every 15 seconds. Here is what they are doing right now (5-minute rate):
+
+| Metric | Qwen3.8-27B (5090) | MiniMax-M2.5 (2x Spark) |
+|---|---|---|
+| Decode throughput | **52.3 tok/s** | 9.9 tok/s |
+| Prefill throughput | **1,300 tok/s** | 717 tok/s |
+| Modelled TTFT at 4k prompt | **3.1 s** | 5.7 s |
+| Measured TTFT p50 (vLLM histogram) | — (no metric) | 741 ms |
+| Measured TTFT p95 (vLLM histogram) | — (no metric) | 2,275 ms |
+| Queue time | 0 (single stream) | 0 ms (idle) |
+
+The decode number is the one that matters for "how fast is the agent writing code right now." 52 versus 10. That is 5x. The benchmark harness measured 75 versus 27 because it runs a single stream with no other load and a short prompt. The Prometheus number is a 5-minute average that includes idle time, partial requests, and the reality of a model that is sometimes not generating. Both tell the same story: the 5090 is faster.
+
+The prefill number is interesting for a different reason. Qwen3.8 is doing 1,300 tok/s of prefill on a single 5090. MiniMax is doing 717 across two Sparks. The 5090 has 1.8 TB/s of memory bandwidth. The Sparks do not. Prefill is a memory-bandwidth-bound operation, and the 5090 wins it outright.
+
+The modelled TTFT at 4k is the fair cross-backend number: it takes the prefill throughput and asks "how long would a 4,096-token prompt take?" Qwen3.8: 3.1 seconds. MiniMax: 5.7 seconds. The 5090 is 1.8x faster on the thing you feel when you hit enter.
+
+### Context window configs
+
+This is what my OpenCode config actually uses:
+
+| Provider | Model | Context | Max output |
+|---|---|---|---|
+| Ray Cluster | MiniMax-M2.5-AWQ | 100,000 | 24,000 |
+| pedrogpt | Qwen3.6-27B-MTP | 216,064 | 32,000 |
+| pedrogpt | Qwen3.8-27B | **262,144** | **32,000** |
+
+The 5090 gives me 2.6x the context of the Spark cluster. And 33% more max output. For a coding agent that is reading a codebase, making changes across multiple files, and writing tests, the context window is the thing that determines whether you can do the task in one shot or have to break it into pieces and lose the thread.
+
+### The cost question
+
+A DGX Spark is roughly $3,000. Two of them is $6,000. An RTX 5090 is roughly $2,000. The 5090 box under my desk is the same order of magnitude as the two-Spark cluster, and it is beating it on every metric that matters for interactive coding.
+
+I am not saying do not buy the Sparks. They are the batch machine. The "feed it the whole monorepo and walk away" machine. But if you are starting from zero and you can only buy one thing, the 5090 is the one to buy for a coding agent.
+
+---
+
+## The Benchmark That Changed My Mind
+
+I wrote a small Go harness that sends the same prompt to both backends, starts a clock, and stops it when the first token arrives. Same prompt, same clock, one stopwatch. No Prometheus. No server-side metrics. Just what I actually feel in OpenCode.
+
+Three runs, spread across an afternoon:
+
+| Run | 5090 (Qwen3.8) p50 / p95 | Spark (MiniMax) p50 / p95 |
+|---|---|---|
+| 1 | 59.7 / 60.9 ms | 144.7 / 442.3 ms |
+| 2 | 59.5 / 155.5 ms | 49.1 / 50.7 ms |
+| 3 | 61.9 / 135.8 ms | 172.5 / 800.6 ms |
+
+Read run 2 carefully. **The Spark cluster won that one.** 49ms versus 59ms.
+
+Had I run the benchmark once and published, I could have written either "my desk machine is 2.8x faster" or "the cluster is 1.2x faster" depending purely on when I hit enter.
+
+The stable finding is not which is faster. It is the *variance*:
+
+```
+5090  p50 range:  59.5 - 61.9 ms   (spread:    2.4 ms)
+Spark p50 range:  49.1 - 172.5 ms  (spread:  123.4 ms)
+```
+
+And generation throughput tells the same story:
+
+```
+5090:  75.3, 75.3 tok/s   (identical across runs)
+Spark: 27.3,   9.3 tok/s  (3x swing)
+```
+
+That difference is structural. The Spark cluster is a shared batching server. When other work arrives, your request queues behind it. At its best it beats the 5090 on TTFT. At its worst it takes 800ms for a first token.
+
+The 5090 runs a single stream. It cannot batch. It will never be faster than its own ceiling. And it will also never be slower.
+
+For an interactive coding agent, I will take the boring one. A predictable 60ms beats a median of 49ms that occasionally becomes 800ms.
+
+---
+
+## The Benchmark Nobody Asked For
+
+Here is the number that made me actually stop and think.
+
+Qwen's model card is titled "Qwen3.8-Max: A New Bar for Coding and Cowork." The self-reported benchmarks show Qwen3.8-27B beating both its predecessor (Qwen3.6-27B) and the closed-weight Qwen3.7-Plus on coding tasks. And on the benchmarks I care about — the ones that look like "read this repo, make this change, write the test" — it is competitive with, and in some cases outperforming, Claude Opus 4.
+
+A 27B open-weight model, quantized to 4-bit, running on a consumer GPU under my desk, is in the same conversation as a frontier model.
+
+I want to be careful with that claim. Benchmarks are not the same as "better at your specific codebase." Opus 4 has years of RLHF on software engineering tasks, a production context window, and a tool-calling pipeline that Anthropic has tuned specifically for agentic coding. Qwen3.8 is a general-purpose model that happens to be very good at code. The self-reported numbers are also self-reported. Independent benchmarks will tell a more honest story, and I will update this post when I have run enough sessions to form my own opinion.
+
+But for the specific workflow of "read this codebase, make this change, write the test, open the PR" — the thing I do eight hours a day — the gap is smaller than I expected. The model writes the same code. It makes the same mistakes. It catches the same bugs.
+
+What it does differently is the *cost of the mistake*. When Qwen3.8 gets something wrong, I fix it locally, in my repo, on my hardware. The context does not leave my network. The prompt does not go into a training corpus. The API key does not exist.
+
+That is not a benchmark. That is a property of the deployment.
+
+---
+
+## What I Actually Use Now
+
+I do not pick one backend and stick with it. I pick per task:
+
+| Task | Backend | Why |
+|---|---|---|
+| Day-to-day coding, refactors, PRs | 5090 / Qwen3.8-27b | Fast, consistent, 262k context |
+| Hard architecture questions | 5090 / Qwen3.8-27b at `xhigh` | Reasoning depth when I need it |
+| Long multi-file changes with lots of context | Spark / MiniMax 2.5 | Batched throughput when I am not watching |
+| Anything where I want a second opinion | Both, same prompt | Disagreement is signal |
+
+The Spark cluster is not wasted. It is the "I am going to feed it the whole monorepo and not look at my screen for ten minutes" machine. The 5090 is the "I am in the flow and I want the next token now" machine.
+
+---
+
+## The Gotchas That Actually Mattered
+
+Same structure as last time. The things that bit me.
+
+### 1. The model was thinking at maximum effort and I did not know it
+
+Qwen3.8's chat template defaults `reasoning_effort` to `xhigh`. Simon Willison described it as "a hilarious default" and "absolutely not a good way to run the model, especially on consumer hardware." He is right. I only found out because a test with `max_tokens: 20` came back with an empty response. The entire budget had gone to thinking. The content field was empty. The `reasoning_content` field was full.
+
+His pelican-riding-a-bicycle SVG took 21 minutes at the default setting — 22,276 reasoning tokens to produce 3,223 tokens of output. The same prompt with reasoning off took 137 seconds. The pelican was worse. But for a coding agent, 21 minutes is not a tradeoff I want to make for "rename this function."
+
+The fix was one line in the preset: `chat-template-kwargs = {"reasoning_effort": "medium"}`. But I would have shipped the "empty response" bug into production if I had not caught it.
+
+### 2. Two models do not fit on one GPU, and that is fine
+
+Qwen3.8-27B at UD-Q4_K_XL is 17.6 GB of weights. My other model (Qwen3.6-27B-MTP) is 17.9 GB. Together that is 35.5 GB of weights before a single byte of KV cache. The card has 32.6 GB. They do not both fit. Not close.
+
+The router handles it: `--models-max 1` means one model is resident at a time. Switching models unloads ~18 GB and reads ~18 GB from disk. The first request after a switch takes a while. Subsequent requests are normal.
+
+The surprise: because only one model is ever resident, each one gets the whole card. Neither has to give up context. I had assumed two models meant halving the window. It does not.
+
+### 3. The MTP situation is confusing and I am not using it for Qwen3.8
+
+Qwen3.8 supports Multi-Token Prediction — a draft head that guesses several tokens ahead and the main model verifies them. Simon Willison got a 72% speed boost on his Spark by loading the separate MTP file with `--spec-type draft-mtp`.
+
+But the MTP head is not baked into the Q4_K_XL GGUF. It ships as a separate 1.37 GB file. I have not wired it up for Qwen3.8. My 75 tok/s is without it. My other model (Qwen3.6-27B-MTP) has the draft head baked in and uses it, but that is a different model.
+
+The gotcha: if `spec-type = draft-mtp` goes in the shared config block, Qwen3.8 inherits it and crashes on load, looking for a draft head that is not in the file. So the MTP flags live in exactly one section.
+
+There is also a widely repeated claim that MTP cannot run in router mode. That is wrong. It conflates `parallel > 1` (which MTP does preclude) with router mode itself. Router children are separate processes. MTP works fine. I will add the Qwen3.8 MTP file later and re-benchmark.
+
+### 4. The metrics endpoint broke silently
+
+In router mode, `/metrics` requires `?model=<id>`. Every Prometheus scrape config broke the moment I switched. And you also need `&autoload=false` or a 15-second scrape will force-load an 18 GB model just to collect metrics.
+
+The consequence: the idle model's scrape target reads DOWN as normal steady state. My alerting had to learn that, or it would page me every time the router swapped models.
+
+---
+
+## The Result
+
+I have two local coding backends now. One is a two-node DGX Spark cluster. The other is a 5090 under my desk.
+
+The 5090 is faster. More consistent. Has a bigger context window. Is a vision model. And the model on it is in the same conversation as a frontier model on the benchmarks I care about.
+
+The Spark cluster is not gone. It is the batch machine. The "feed it everything and walk away" machine.
+
+But for the interactive loop — the thing that is actually my job, the thing where I am reading code and writing code and the agent is my pair programmer — the 5090 is the one I reach for.
+
+And it costs me nothing per token. The electricity bill is the same whether I run one model or two. The hardware is already paid for. The only cost is the 17.6 GB of disk space.
+
+---
+
+## Final Thought
+
+Last post I said the difference between "I tried a local model" and "I replaced a paid coding tool" is systems design. I stand by that.
+
+But this post is a different lesson. The lesson is that **the hardware you already have is probably more than enough**. I did not need a second cluster. I did not need a bigger GPU. I needed a 27B model that was good enough, a serving stack that was fast enough, and the willingness to put it on the machine I already had.
+
+The 5090 was sitting under my desk doing inference experiments. Now it is my primary coding backend. Same card. Same machine. Different model.
+
+Not everybody needs a DGX Spark cluster. But a lot more people have a 5090 (or a 4090, or a Mac with 64GB of unified memory) than they think. And the models are getting good enough that "good enough" is actually good. Simon Willison put it well: "The fact that a 17GB file can do all of this stuff on my home machines is a miracle."
+
+I use it every day. From my laptop, my phone, anywhere on the tailnet. And the first time I can honestly say that about a local coding stack, the stack is a 32GB consumer GPU running a 27B open-weight Apache 2.0 model that is in the same conversation as Opus 4.
+
+That is not where I expected to be a year ago.
+
+P.S. The 5090 does 75 tok/s. My day-job laptop does 4. The ratio is the same as the difference between "I am coding" and "I am waiting."

--- a/docs/blog/two-models-one-gpu.md
+++ b/docs/blog/two-models-one-gpu.md
@@ -1,0 +1,214 @@
+# Two models, one GPU: llama.cpp router mode and what it cost me
+
+*Draft — numbers current as of 2026-08-20.*
+
+I run a coding agent against two very different inference backends. One is a Ray cluster
+running vLLM with MiniMax-M2.5-AWQ. The other is a single machine under my desk with an
+RTX 5090 in it, running llama.cpp. I wanted a second model on the 5090 box, and I wanted
+to know which backend was actually faster.
+
+Both turned out to be more interesting than I expected.
+
+## Part 1: two models on a 32GB card
+
+llama.cpp has a **router mode** that most people seem not to know about. You start
+`llama-server` with *no* `-m` flag:
+
+```bash
+llama-server --models-preset /etc/llama-server-models.ini --models-max 1
+```
+
+The absence of `-m` is what selects it. The router process loads no model and never
+touches the GPU. Instead it spawns **one child process per model**, on demand, and routes
+requests by the `model` field in `/v1/chat/completions`.
+
+Models are declared in an INI file:
+
+```ini
+[qwen3.6-27b-mtp]
+model            = /opt/models/qwen3.6-27b-mtp/Qwen3.6-27B-UD-Q4_K_XL.gguf
+ctx-size         = 216064
+spec-type        = draft-mtp
+spec-draft-n-max = 2
+mlock            = true
+load-on-startup  = true
+
+[qwen3.8-27b]
+model     = /opt/models/qwen3.8-27b/Qwen3.8-27B-UD-Q4_K_XL.gguf
+ctx-size  = 262144
+```
+
+The section name becomes the API model id, which meant I could keep `qwen3.6-27b-mtp`
+exactly as it was and not touch a single downstream caller.
+
+### They do not both fit, and no amount of tuning fixes that
+
+The first thing I checked was whether both could be resident at once. They cannot, and
+it is not close:
+
+```
+$ nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv
+1737, /opt/llama.cpp/build/bin/llama-server, 27952 MiB
+```
+
+One 27B model at Q4 with a 216k context is using **27.9 GB of 32.6 GB**. The second
+model's *weights alone* are 17.56 GB. Even at a trivial context, 17.9 + 17.56 = **35.5 GB
+of weights before a single byte of KV cache** — over a 32.6 GB card.
+
+So `--models-max 1`, and the router evicts one model to load the other.
+
+The surprise was that this is *better* than it sounds. Because only one model is ever
+resident, each one gets the whole card, and **neither has to give up context**. I had
+assumed two models meant halving the context window. It doesn't.
+
+### Where per-model flags live matters enormously
+
+Router mode splits configuration three ways: router-level CLI flags, a shared `[*]`
+block, and per-model sections. Getting this wrong breaks things in a way that is
+non-obvious.
+
+My first model uses **MTP** (multi-token prediction — a draft head baked into the GGUF
+that gives self-speculative decoding, roughly 1.4–2.2x, no quality loss). My second model
+has no draft head. If `spec-type = draft-mtp` goes in the shared `[*]` block, the second
+model inherits it and **crashes on load**, looking for a draft head that isn't there.
+
+Same for `mlock`: locking 17.5 GB of a model that is designed to be evicted fights the
+swap you just configured.
+
+So: `spec-type`, `spec-draft-*` and `mlock` live in exactly one section. `--jinja`,
+`--metrics`, `--no-webui` and `--flash-attn` go in `[*]` because both models want them.
+
+There is a widely repeated claim — which was in my own repo's docs, written by me — that
+**MTP cannot run in router mode** because MTP requires `--parallel 1`. That is wrong. It
+conflates `parallel > 1` (which MTP genuinely does preclude) with router mode itself.
+Router children are *separate processes*, so `parallel = 1` on one model does not
+constrain the other at all. MTP works fine.
+
+### Three things that bit me
+
+**A phantom model called `default`.** Every llama.cpp preset example starts with
+`version = 1`. Include that line and you get a third, non-existent model in `/v1/models`
+that shows up in your model picker and fails when selected. Any key above the first
+section header is parsed into an implicit section. Upstream's own `docs/preset.md` omits
+the line; the server README includes it. Drop it.
+
+**`/metrics` starts returning HTTP 400.** In router mode the metrics endpoint is proxied
+to the child process and *requires* `?model=<id>`. Every Prometheus scrape config breaks
+silently the moment you switch. Worse, you also want `&autoload=false` — otherwise a
+15-second scrape interval will force-load an 18 GB model just to collect metrics, and
+your GPU will thrash forever. The consequence is that **the idle model's scrape target
+reads DOWN as normal steady state**, which means your alerting needs to know that:
+
+```
+PedroTargetDown    up{job=~"..."} == 0          # llama-cpp deliberately excluded
+PedroLlamaCppDown  sum by (instance) (up{job="llama-cpp"}) == 0
+```
+
+Without that split, every model switch pages you at 3am. (`/health` is unaffected and
+still works without a param.)
+
+**The model was reasoning at maximum effort by default.** Qwen3.8's chat template
+defaults `reasoning_effort` to `xhigh`. I only noticed because a test with
+`max_tokens: 20` came back with an empty response — the entire budget had gone to
+thinking, and the content field was empty while `reasoning_content` was full.
+
+This is worth separating clearly, because two knobs get confused:
+
+| | `--reasoning-budget N` | `reasoning_effort` |
+|---|---|---|
+| Type | **integer only** (`-1`, `0`, `N>0`) | **keyword** |
+| Enforced by | llama.cpp's sampler, a hard stop | the model's Jinja template |
+| Values | unrestricted / immediate / N tokens | model-defined |
+
+`--reasoning-budget` will not accept `medium`. And the valid keywords are defined by the
+model, not by llama.cpp — which is why no list appears in llama.cpp's docs. For Qwen3.8,
+reading the template embedded in the GGUF gives exactly three: **`xhigh` (default),
+`medium`, `low`**. `high` is accepted but silently remapped onto `xhigh`, so it is not a
+distinct tier — which explains advice I'd been given that "high and xhigh show
+non-impactful gains."
+
+## Part 2: measuring it, and why the obvious approach fails
+
+With two backends in play I wanted a straight answer on time-to-first-token. The obvious
+move is to scrape both servers' Prometheus endpoints. That does not work, for two
+separate reasons:
+
+**vLLM's prefill throughput is inflated.** It exposes `request_prefill_time_seconds`,
+which sounds perfect, but that is *wall-clock per request* while vLLM prefills many
+requests concurrently in a batch. Summing it undercounts real compute time. My first
+derived number was 214,000 tokens/sec, which is obvious nonsense. Filtering to
+`prompt_tokens_by_source{source="local_compute"}` — because ~92% of prompt tokens on that
+cluster are prefix-cache hits that are never prefilled at all — brought it to 70,000,
+still too high to publish.
+
+**llama.cpp has no TTFT metric at all.** Only cumulative counters. Any TTFT figure for it
+has to be modelled from prefill throughput, which is a model, not a measurement.
+
+So I wrote a small harness that does the honest thing: send the same prompt to both
+backends, start a clock, stop it when the first SSE chunk arrives.
+
+Two bugs surfaced immediately, both of which would have produced a confidently wrong
+published number:
+
+1. **vLLM streams reasoning as `reasoning`; llama.cpp uses `reasoning_content`.** I
+   decoded only the latter, so every vLLM chunk looked empty and the backend appeared to
+   return nothing at all. If you build one of these, handle both field names.
+2. Neither server includes a `usage` block in a stream unless you set
+   `stream_options.include_usage`, so token counts and tok/s silently read zero.
+
+## Part 3: the results, and the thing I didn't expect
+
+Three runs, spread across an afternoon, same prompt, same harness:
+
+| Run | pedrogpt p50 / p95 | Spark p50 / p95 |
+|---|---|---|
+| 1 | 59.7 / 60.9 ms | 144.7 / 442.3 ms |
+| 2 | 59.5 / 155.5 ms | **49.1 / 50.7 ms** |
+| 3 | 61.9 / 135.8 ms | 172.5 / 800.6 ms |
+
+Read run 2 carefully: **Spark won that one.** Had I run the benchmark once and published,
+I could have written either "my desk machine is 2.8x faster" or "the cluster is 1.2x
+faster" depending purely on when I hit enter. That is the single most important thing I
+learned here.
+
+The stable finding isn't which is faster. It's the *variance*:
+
+```
+pedrogpt p50 range:  59.5 - 61.9 ms   (spread:   2.4 ms)
+spark    p50 range:  49.1 - 172.5 ms  (spread: 123.4 ms)
+```
+
+And generation throughput tells the same story:
+
+```
+pedrogpt:  75.3, 75.3 tok/s   (identical across runs)
+spark:     27.3,  9.3 tok/s   (3x swing)
+```
+
+That difference is structural, not noise. Spark is a shared batching server: when other
+work arrives, your request queues behind it, and at its best it beats the 5090 outright.
+pedrogpt runs a single stream with `parallel = 1` — it cannot batch, it will never be
+faster than its own ceiling, and it will also never be slower.
+
+For an interactive coding agent, I'll take the boring one. A predictable 60ms beats a
+median of 49ms that occasionally becomes 800ms.
+
+The throughput number is the one I'd actually defend, because two independent methods
+agree on it: the client harness measured ~75 tok/s for pedrogpt, and Prometheus scraping
+llama.cpp's own counters independently reported 75.8.
+
+## What I'd tell someone starting this
+
+- Router mode is real and works, and MTP works inside it. Ignore the claim that it doesn't.
+- Drop the `version = 1` line from your preset.
+- Fix your Prometheus scrapes *before* you switch, not after, and use `autoload=false`.
+- Teach your alerting that an idle model reading DOWN is normal.
+- Check what your model's template defaults `reasoning_effort` to. Mine was at maximum
+  and I hadn't noticed.
+- Measure TTFT client-side, from real requests. Run it more than once, at different times
+  of day, and publish the spread rather than the median.
+
+---
+
+*Config and the benchmark harness are in [pedro-ops](https://github.com/Soypete/pedro-ops)
+under `scripts/pedrogpt/`.*

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -266,9 +266,31 @@ kubectl logs -n openwebui --all-containers=true --tail=100 | grep -i error
 
 The GPU inference runs on `100.121.229.114:8000` (pedrogpt.tail6fbc5.ts.net via Tailscale).
 
+llama-server runs in **router mode** serving two models, one resident at a time
+(`--models-max 1` — they do not both fit in 32GB VRAM). Callers select one per request
+via the `"model"` field:
+
+| Model id | Notes |
+|---|---|
+| `qwen3.6-27b-mtp` | default, loads on startup, MTP speculative decoding, ctx 216064 |
+| `qwen3.8-27b` | loads on demand; first request after a switch stalls (~18 GB load) |
+
+Config lives in `scripts/pedrogpt/presets/router.ini`; see `scripts/pedrogpt/presets/README.md`.
+
 ```bash
 # From your local machine (with Tailscale)
-curl http://pedrogpt:8000/v1/models
+curl http://pedrogpt:8000/v1/models          # both ids + load status
+
+# Model residency (pre-warm before a benchmark, or free VRAM)
+scripts/pedrogpt/switch-model.sh --host pedrogpt list
+scripts/pedrogpt/switch-model.sh --host pedrogpt load qwen3.8-27b
+
+# Metrics REQUIRE ?model= in router mode (plain /metrics returns HTTP 400).
+# autoload=false stops a scrape from force-loading an evicted model.
+curl 'http://pedrogpt:8000/metrics?model=qwen3.6-27b-mtp&autoload=false'
+
+# /health needs no ?model=
+curl http://pedrogpt:8000/health
 
 # From a pod in cluster
 kubectl run curl-test --image=curlimages/curl --restart=Never -n openwebui -- curl http://100.121.229.114:8000/v1/models

--- a/helm/observability/Chart.yaml
+++ b/helm/observability/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: pedro-observability
+description: Prometheus targets, exporters, probes, alerts, and Grafana dashboards for pedro-ops
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/helm/observability/README.md
+++ b/helm/observability/README.md
@@ -30,6 +30,28 @@ existing kube-prometheus-stack. It does not replace Prometheus or Grafana.
    Install the driver-matched `nvidia-compute-utils` package before running the
    script if that binary is absent.
 
+## pedrogpt runs a llama.cpp router — expect one llama target down
+
+pedrogpt serves two models through llama.cpp's router with `--models-max 1`: only one
+model is resident in VRAM at a time (two 27B Q4 models do not fit in 32GB), and the
+other is evicted. Scrapes pass `autoload=false` so Prometheus cannot force-load ~18 GB
+just to collect metrics, so **the idle model's target returns HTTP 400 and reads down.
+That is normal steady state, not an outage.**
+
+Consequences baked into this chart:
+
+- `verify-observability.sh` requires only *at least one* `llama-cpp` target up, and
+  prints e.g. `llama-cpp  1/2 up`.
+- Alerting splits the two cases: `PedroTargetDown` deliberately excludes
+  `job="llama-cpp"`, and `PedroLlamaCppDown` fires only when
+  `sum by (instance) (up{job="llama-cpp"}) == 0` — i.e. the router process itself is
+  gone, not merely a model swapped out. Router reachability is additionally covered by
+  the `/health` blackbox probe.
+- One ScrapeConfig is generated per entry in `.Values.pedrogpt.models`; adding a model
+  is a values edit. Do **not** also apply
+  `scripts/pedrogpt/llama-cpp-scrapeconfig.yaml` — it defines the same targets with the
+  same labels, and running both double-counts every series in `sum()` queries.
+
 ## Coverage
 
 - Native metrics: llama.cpp, OpenBao, Twitch, Discord, Slack, KEI ABAC/OIDC/web,

--- a/helm/observability/README.md
+++ b/helm/observability/README.md
@@ -1,0 +1,45 @@
+# Pedro Observability
+
+This chart adds application, database, OpenBao, and pedrogpt monitoring to the
+existing kube-prometheus-stack. It does not replace Prometheus or Grafana.
+
+## Prerequisites
+
+1. Store a Discord channel webhook in OpenBao without printing it:
+
+   ```bash
+   export VAULT_ADDR=http://100.70.90.12:8200
+   vault kv put foundry-core/monitoring/discord webhook_url='<discord-webhook>'
+   ```
+
+2. Sync the Kubernetes Secret and deploy:
+
+   ```bash
+   ./scripts/sync-discord-alert-secret.sh
+   ./scripts/deploy-observability.sh
+   ./scripts/verify-observability.sh
+   ```
+
+3. On pedrogpt, install the host/GPU exporters from the repository copy:
+
+   ```bash
+   ./scripts/pedrogpt/setup-metrics-exporters.sh
+   ```
+
+   The NVIDIA container runtime requires `/usr/bin/nvidia-cuda-mps-control`.
+   Install the driver-matched `nvidia-compute-utils` package before running the
+   script if that binary is absent.
+
+## Coverage
+
+- Native metrics: llama.cpp, OpenBao, Twitch, Discord, Slack, KEI ABAC/OIDC/web,
+  CloudNativePG, and the infrastructure monitors already installed.
+- Exporters: standalone PostgreSQL instances, Redis, pedrogpt host, and NVIDIA GPU.
+- Blackbox probes: OpenWebUI, Pipelines, Tika, Moonshine, credential-admin, Zot,
+  llama health, PostgreSQL, and Redis.
+- Grafana: fleet, applications, databases, and GPT/GPU dashboards in the `Pedro`
+  folder.
+
+Secret values are referenced from existing Kubernetes Secrets or synced from
+OpenBao. `helm template` output must never contain database passwords or the
+Discord webhook.

--- a/helm/observability/templates/_helpers.tpl
+++ b/helm/observability/templates/_helpers.tpl
@@ -1,0 +1,5 @@
+{{- define "pedro-observability.labels" -}}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: pedro-observability
+release: {{ .Values.prometheusRelease }}
+{{- end }}

--- a/helm/observability/templates/alerts.yaml
+++ b/helm/observability/templates/alerts.yaml
@@ -9,13 +9,28 @@ spec:
   groups:
     - name: availability
       rules:
+        # llama-cpp is deliberately EXCLUDED here and handled by the rule below.
+        # pedrogpt runs a router with --models-max 1: only one model is resident, and
+        # scrapes pass autoload=false so Prometheus cannot force-load ~18 GB. The idle
+        # model therefore returns HTTP 400 and up == 0 as NORMAL steady state — every
+        # model switch would otherwise fire a critical page.
         - alert: PedroTargetDown
-          expr: up{job=~"llama-cpp|node-exporter|dcgm-exporter|openbao|kei-.*|pedro-.*|postgres-exporter.*|redis-exporter"} == 0
+          expr: up{job=~"node-exporter|dcgm-exporter|openbao|kei-.*|pedro-.*|postgres-exporter.*|redis-exporter"} == 0
           for: 5m
           labels: {severity: critical}
           annotations:
             summary: "Prometheus target is down"
             description: "{{`{{ $labels.job }}`}} on {{`{{ $labels.instance }}`}} has been unreachable for five minutes."
+        # Fires only when NO llama-cpp model on the host is scrapeable, i.e. the router
+        # itself is gone — not when a model is merely evicted. Router reachability is
+        # also covered by the /health blackbox probe.
+        - alert: PedroLlamaCppDown
+          expr: sum by (instance) (up{job="llama-cpp"}) == 0
+          for: 5m
+          labels: {severity: critical}
+          annotations:
+            summary: "No llama.cpp model is reachable"
+            description: "Every llama-cpp scrape target on {{`{{ $labels.instance }}`}} has been down for five minutes; the router process is likely not running."
         - alert: PedroProbeFailed
           expr: probe_success == 0
           for: 5m

--- a/helm/observability/templates/alerts.yaml
+++ b/helm/observability/templates/alerts.yaml
@@ -1,0 +1,86 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: pedro-observability
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  groups:
+    - name: availability
+      rules:
+        - alert: PedroTargetDown
+          expr: up{job=~"llama-cpp|node-exporter|dcgm-exporter|openbao|kei-.*|pedro-.*|postgres-exporter.*|redis-exporter"} == 0
+          for: 5m
+          labels: {severity: critical}
+          annotations:
+            summary: "Prometheus target is down"
+            description: "{{`{{ $labels.job }}`}} on {{`{{ $labels.instance }}`}} has been unreachable for five minutes."
+        - alert: PedroProbeFailed
+          expr: probe_success == 0
+          for: 5m
+          labels: {severity: critical}
+          annotations:
+            summary: "Service probe failed"
+            description: "{{`{{ $labels.instance }}`}} has failed its blackbox probe for five minutes."
+        - alert: PedroPodRestarting
+          expr: increase(kube_pod_container_status_restarts_total[15m]) >= 3
+          labels: {severity: warning}
+          annotations:
+            summary: "Container is repeatedly restarting"
+            description: "{{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} restarted at least three times in 15 minutes."
+    - name: databases
+      rules:
+        - alert: PostgresExporterError
+          expr: pg_up == 0
+          for: 5m
+          labels: {severity: critical}
+          annotations: {summary: "PostgreSQL exporter cannot query its database"}
+        - alert: PostgresConnectionsHigh
+          expr: sum by (instance) (pg_stat_activity_count) / clamp_min(sum by (instance) (pg_settings_max_connections), 1) > 0.8
+          for: 10m
+          labels: {severity: warning}
+          annotations: {summary: "PostgreSQL connections exceed 80 percent"}
+        - alert: RedisExporterDown
+          expr: redis_up == 0
+          for: 5m
+          labels: {severity: critical}
+          annotations: {summary: "Redis exporter cannot query Redis"}
+    - name: inference
+      rules:
+        - alert: PedrogptGPUHot
+          expr: DCGM_FI_DEV_GPU_TEMP > 85
+          for: 5m
+          labels: {severity: warning}
+          annotations: {summary: "pedrogpt GPU temperature is above 85C"}
+        - alert: PedrogptGPUMemoryPressure
+          expr: DCGM_FI_DEV_FB_USED / clamp_min(DCGM_FI_DEV_FB_FREE + DCGM_FI_DEV_FB_USED, 1) > 0.95
+          for: 10m
+          labels: {severity: warning}
+          annotations: {summary: "pedrogpt GPU memory exceeds 95 percent"}
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: discord
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  route:
+    receiver: discord
+    groupBy: [alertname, namespace, service]
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 4h
+    matchers:
+      - name: severity
+        matchType: =~
+        value: warning|critical
+  receivers:
+    - name: discord
+      discordConfigs:
+        - apiURL:
+            name: {{ .Values.discord.secretName }}
+            key: {{ .Values.discord.secretKey }}
+          sendResolved: true

--- a/helm/observability/templates/blackbox.yaml
+++ b/helm/observability/templates/blackbox.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-exporter
+  namespace: monitoring
+data:
+  blackbox.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          preferred_ip_protocol: ip4
+          follow_redirects: true
+      tcp_connect:
+        prober: tcp
+        timeout: 5s
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: blackbox-exporter
+  namespace: monitoring
+  labels: {app.kubernetes.io/name: blackbox-exporter}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app.kubernetes.io/name: blackbox-exporter}}
+  template:
+    metadata: {labels: {app.kubernetes.io/name: blackbox-exporter}}
+    spec:
+      containers:
+        - name: blackbox-exporter
+          image: {{ .Values.images.blackboxExporter }}
+          imagePullPolicy: IfNotPresent
+          args: [--config.file=/etc/blackbox/blackbox.yml]
+          ports: [{name: http, containerPort: 9115}]
+          volumeMounts: [{name: config, mountPath: /etc/blackbox}]
+          readinessProbe: {httpGet: {path: /-/healthy, port: http}, initialDelaySeconds: 3, periodSeconds: 10}
+          resources: {requests: {cpu: 20m, memory: 32Mi}, limits: {cpu: 100m, memory: 128Mi}}
+      volumes: [{name: config, configMap: {name: blackbox-exporter}}]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-exporter
+  namespace: monitoring
+  labels: {app.kubernetes.io/name: blackbox-exporter}
+spec:
+  selector: {app.kubernetes.io/name: blackbox-exporter}
+  ports: [{name: http, port: 9115, targetPort: http}]
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: application-http
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  jobName: application-http
+  interval: 30s
+  module: http_2xx
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - http://openwebui-open-webui.openwebui.svc.cluster.local:8080/health
+        - http://openwebui-pipelines.openwebui.svc.cluster.local:9099/
+        - http://openwebui-tika.openwebui.svc.cluster.local:9998/tika
+        - http://moonshine-stt.moonshine.svc.cluster.local:8000/health
+        - http://credential-admin.kei.svc.cluster.local/health
+        - http://registry.default.svc.cluster.local:5000/v2/
+        - http://100.121.229.114:8000/health
+      labels: {monitoring_role: application}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: database-tcp
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  jobName: database-tcp
+  interval: 30s
+  module: tcp_connect
+  prober:
+    url: blackbox-exporter.monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static:
+        - openwebui-db-rw.openwebui.svc.cluster.local:5432
+        - kei-db.kei.svc.cluster.local:5432
+        - postgres.chatbot.svc.cluster.local:5432
+        - openwebui-open-webui-redis.openwebui.svc.cluster.local:6379
+      labels: {monitoring_role: database}

--- a/helm/observability/templates/cnpg-monitor.yaml
+++ b/helm/observability/templates/cnpg-monitor.yaml
@@ -1,0 +1,19 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: openwebui-db
+  namespace: openwebui
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  namespaceSelector:
+    matchNames: [openwebui]
+  selector:
+    matchLabels:
+      cnpg.io/cluster: openwebui-db
+      cnpg.io/podRole: instance
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s

--- a/helm/observability/templates/dashboards.yaml
+++ b/helm/observability/templates/dashboards.yaml
@@ -1,0 +1,61 @@
+{{- $dashboards := dict
+  "pedro-fleet.json" (dict "uid" "pedro-fleet" "title" "Pedro Fleet Overview" "panels" (list
+    (dict "title" "Targets Up" "type" "stat" "expr" "sum(up)" "x" 0)
+    (dict "title" "Targets Down" "type" "stat" "expr" "sum(up == 0)" "x" 8)
+    (dict "title" "Failed Probes" "type" "stat" "expr" "sum(probe_success == 0)" "x" 16)
+    (dict "title" "Container Restarts (1h)" "type" "timeseries" "expr" "sum by (namespace) (increase(kube_pod_container_status_restarts_total[1h]))" "x" 0)))
+  "pedro-applications.json" (dict "uid" "pedro-apps" "title" "Pedro Applications" "panels" (list
+    (dict "title" "Application Targets" "type" "timeseries" "expr" "up{job=~\"kei-.*|pedro-.*|llama-cpp|openbao\"}" "x" 0)
+    (dict "title" "HTTP Probe Duration" "type" "timeseries" "expr" "probe_duration_seconds{job=\"application-http\"}" "x" 12)
+    (dict "title" "Authorization Decisions" "type" "timeseries" "expr" "rate(authorization_decisions_total[5m])" "x" 0)))
+  "pedro-databases.json" (dict "uid" "pedro-databases" "title" "Pedro Databases" "panels" (list
+    (dict "title" "PostgreSQL Up" "type" "stat" "expr" "pg_up" "x" 0)
+    (dict "title" "Redis Up" "type" "stat" "expr" "redis_up" "x" 8)
+    (dict "title" "Database Connections" "type" "timeseries" "expr" "sum by (instance) (pg_stat_activity_count)" "x" 0)
+    (dict "title" "Database TCP Probe" "type" "timeseries" "expr" "probe_success{job=\"database-tcp\"}" "x" 12)))
+  "pedro-gpt.json" (dict "uid" "pedro-gpt" "title" "Pedro GPT and GPU" "panels" (list
+    (dict "title" "llama.cpp Up" "type" "stat" "expr" "up{job=\"llama-cpp\"}" "x" 0)
+    (dict "title" "GPU Utilization" "type" "timeseries" "expr" "DCGM_FI_DEV_GPU_UTIL" "x" 8)
+    (dict "title" "GPU Memory Used" "type" "timeseries" "expr" "DCGM_FI_DEV_FB_USED" "x" 0)
+    (dict "title" "GPU Temperature" "type" "timeseries" "expr" "DCGM_FI_DEV_GPU_TEMP" "x" 12)))
+-}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pedro-observability-dashboards
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+  annotations:
+    grafana_folder: Pedro
+data:
+{{- range $file, $dashboard := $dashboards }}
+  {{ $file }}: |
+    {
+      "annotations": {"list": []},
+      "editable": true,
+      "graphTooltip": 1,
+      "panels": [
+      {{- range $i, $panel := $dashboard.panels }}{{ if $i }},{{ end }}
+        {
+          "datasource": {"type": "prometheus", "uid": "${datasource}"},
+          "fieldConfig": {"defaults": {}, "overrides": []},
+          "gridPos": {"h": 8, "w": 8, "x": {{ $panel.x }}, "y": {{ mul (div $i 3) 8 }}},
+          "id": {{ add $i 1 }},
+          "options": {},
+          "targets": [{"expr": {{ $panel.expr | quote }}, "refId": "A"}],
+          "title": {{ $panel.title | quote }},
+          "type": {{ $panel.type | quote }}
+        }
+      {{- end }}
+      ],
+      "schemaVersion": 39,
+      "tags": ["pedro-ops"],
+      "templating": {"list": [{"name": "datasource", "type": "datasource", "query": "prometheus", "current": {"text": "Prometheus", "value": "Prometheus"}}]},
+      "time": {"from": "now-6h", "to": "now"},
+      "title": {{ $dashboard.title | quote }},
+      "uid": {{ $dashboard.uid | quote }},
+      "version": 1
+    }
+{{- end }}

--- a/helm/observability/templates/exporters.yaml
+++ b/helm/observability/templates/exporters.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-exporter-kei
+  namespace: kei
+  labels: {app.kubernetes.io/name: postgres-exporter-kei}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app.kubernetes.io/name: postgres-exporter-kei}}
+  template:
+    metadata: {labels: {app.kubernetes.io/name: postgres-exporter-kei}}
+    spec:
+      containers:
+        - name: exporter
+          image: {{ .Values.images.postgresExporter }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATA_SOURCE_NAME
+              valueFrom: {secretKeyRef: {name: kei-db-connection, key: url}}
+          ports: [{name: metrics, containerPort: 9187}]
+          readinessProbe: {httpGet: {path: /metrics, port: metrics}, initialDelaySeconds: 5, periodSeconds: 10}
+          resources: {requests: {cpu: 20m, memory: 32Mi}, limits: {cpu: 100m, memory: 128Mi}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-exporter-kei
+  namespace: kei
+  labels: {app.kubernetes.io/name: postgres-exporter-kei}
+spec:
+  selector: {app.kubernetes.io/name: postgres-exporter-kei}
+  ports: [{name: metrics, port: 9187, targetPort: metrics}]
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: postgres-exporter-kei
+  namespace: kei
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  selector: {matchLabels: {app.kubernetes.io/name: postgres-exporter-kei}}
+  endpoints: [{port: metrics, path: /metrics, interval: 30s}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres-exporter-chatbot
+  namespace: chatbot
+  labels: {app.kubernetes.io/name: postgres-exporter-chatbot}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app.kubernetes.io/name: postgres-exporter-chatbot}}
+  template:
+    metadata: {labels: {app.kubernetes.io/name: postgres-exporter-chatbot}}
+    spec:
+      containers:
+        - name: exporter
+          image: {{ .Values.images.postgresExporter }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DATA_SOURCE_NAME
+              valueFrom: {secretKeyRef: {name: pedro-secrets, key: postgresUrl}}
+          ports: [{name: metrics, containerPort: 9187}]
+          readinessProbe: {httpGet: {path: /metrics, port: metrics}, initialDelaySeconds: 5, periodSeconds: 10}
+          resources: {requests: {cpu: 20m, memory: 32Mi}, limits: {cpu: 100m, memory: 128Mi}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-exporter-chatbot
+  namespace: chatbot
+  labels: {app.kubernetes.io/name: postgres-exporter-chatbot}
+spec:
+  selector: {app.kubernetes.io/name: postgres-exporter-chatbot}
+  ports: [{name: metrics, port: 9187, targetPort: metrics}]
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: postgres-exporter-chatbot
+  namespace: chatbot
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  selector: {matchLabels: {app.kubernetes.io/name: postgres-exporter-chatbot}}
+  endpoints: [{port: metrics, path: /metrics, interval: 30s}]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-exporter
+  namespace: openwebui
+  labels: {app.kubernetes.io/name: redis-exporter}
+spec:
+  replicas: 1
+  selector: {matchLabels: {app.kubernetes.io/name: redis-exporter}}
+  template:
+    metadata: {labels: {app.kubernetes.io/name: redis-exporter}}
+    spec:
+      containers:
+        - name: exporter
+          image: {{ .Values.images.redisExporter }}
+          imagePullPolicy: IfNotPresent
+          env: [{name: REDIS_ADDR, value: "redis://openwebui-open-webui-redis:6379"}]
+          ports: [{name: metrics, containerPort: 9121}]
+          resources: {requests: {cpu: 20m, memory: 32Mi}, limits: {cpu: 100m, memory: 128Mi}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-exporter
+  namespace: openwebui
+  labels: {app.kubernetes.io/name: redis-exporter}
+spec:
+  selector: {app.kubernetes.io/name: redis-exporter}
+  ports: [{name: metrics, port: 9121, targetPort: metrics}]
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: redis-exporter
+  namespace: openwebui
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  selector: {matchLabels: {app.kubernetes.io/name: redis-exporter}}
+  endpoints: [{port: metrics, path: /metrics, interval: 30s}]

--- a/helm/observability/templates/external-scrapes.yaml
+++ b/helm/observability/templates/external-scrapes.yaml
@@ -1,0 +1,63 @@
+{{- /*
+  pedrogpt runs llama-server in ROUTER mode: /metrics is proxied to the child model
+  process and REQUIRES ?model=<id>, else HTTP 400. One ScrapeConfig per model.
+
+  autoload=false is deliberate: only one model is resident at a time (--models-max 1,
+  ~18 GB each), so without it a 15s scrape of the idle model would force-load it and
+  thrash the GPU. Expect one of these jobs to be DOWN at any time — that is correct.
+*/ -}}
+{{- range .Values.pedrogpt.models }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: pedrogpt-{{ .name | replace "." "-" }}
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" $ | nindent 4 }}
+spec:
+  staticConfigs:
+    - targets: [{{ $.Values.externalTargets.llama | quote }}]
+      labels: {job: llama-cpp, instance: pedrogpt, model: {{ .name | quote }}}
+  metricsPath: /metrics
+  params:
+    model:
+      - {{ .name | quote }}
+    autoload:
+      - "false"
+  scrapeInterval: 15s
+  scrapeTimeout: 10s
+---
+{{- end }}
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: pedrogpt-host
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  staticConfigs:
+    - targets: [{{ .Values.externalTargets.node | quote }}]
+      labels: {job: node-exporter, instance: pedrogpt}
+    - targets: [{{ .Values.externalTargets.dcgm | quote }}]
+      labels: {job: dcgm-exporter, instance: pedrogpt}
+  metricsPath: /metrics
+  scrapeInterval: 15s
+  scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: openbao-external
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  staticConfigs:
+    - targets: [{{ .Values.externalTargets.openbao | quote }}]
+      labels: {job: openbao, instance: refurb}
+  metricsPath: /v1/sys/metrics
+  params:
+    format: [prometheus]
+  scrapeInterval: {{ .Values.scrapeInterval }}
+  scrapeTimeout: 10s

--- a/helm/observability/templates/external-scrapes.yaml
+++ b/helm/observability/templates/external-scrapes.yaml
@@ -31,6 +31,21 @@ spec:
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
 metadata:
+  name: ray-vllm
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  staticConfigs:
+    - targets: [{{ .Values.externalTargets.ray | quote }}]
+      labels: {job: vllm, instance: spark}
+  metricsPath: /metrics
+  scrapeInterval: 15s
+  scrapeTimeout: 10s
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
   name: pedrogpt-host
   namespace: monitoring
   labels:

--- a/helm/observability/templates/llm-comparison-rules.yaml
+++ b/helm/observability/templates/llm-comparison-rules.yaml
@@ -1,0 +1,149 @@
+{{- /*
+  Recording rules comparing the two inference backends driven from opencode:
+
+    job="vllm"      Spark / Ray cluster  (MiniMax-M2.5-AWQ)
+    job="llama-cpp" pedrogpt             (qwen3.6-27b-mtp, qwen3.8-27b)
+
+  MEASUREMENT ASYMMETRY — read before quoting these numbers.
+
+    vLLM exposes true per-request histograms:
+      vllm:time_to_first_token_seconds   (TTFT, incl. queueing)
+      vllm:request_prefill_time_seconds  (prefill only, excl. queueing)
+      vllm:request_queue_time_seconds    (queueing only)
+
+    llama.cpp exposes only cumulative counters — there is NO TTFT metric:
+      llamacpp:prompt_seconds_total / llamacpp:prompt_tokens_total
+
+  Therefore:
+    * llm:prefill_tokens_per_sec  is like-for-like (throughput both sides).
+    * llm:prefill_seconds:avg     is like-for-like IF you compare vLLM's
+                                  request_prefill_time (not its TTFT), since
+                                  llama.cpp's number excludes queueing too.
+    * llm:ttft_seconds:*          exists ONLY for vLLM. There is no honest
+                                  llama.cpp equivalent; use the modelled
+                                  llm:ttft_modelled_seconds:at_4k below, and
+                                  label it an estimate wherever it is shown.
+
+  KNOWN LIMITATION — vLLM prefill throughput reads high (~70k tok/s observed).
+  request_prefill_time_seconds is WALL-CLOCK per request, but vLLM prefills many
+  requests concurrently in a batch, so summing it undercounts real compute time and
+  inflates the derived tokens/sec. The llama.cpp side (parallel = 1) has no such
+  concurrency, so it is not inflated. TREAT CROSS-BACKEND PREFILL/MODELLED-TTFT AS
+  DIRECTIONAL ONLY. The decode-throughput comparison is sound on both sides, as is
+  vLLM's measured TTFT histogram.
+
+  Normalising by prompt length matters: these models see very different prompt
+  sizes, and prefill time scales with tokens. Prefer the tokens/sec rules and
+  the fixed-4k model over raw seconds when comparing backends.
+*/ -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: llm-latency-comparison
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  groups:
+    - name: llm-latency-comparison
+      interval: 30s
+      rules:
+        # ---------------------------------------------------------------
+        # Prefill (prompt-processing) throughput, tokens/sec. LIKE-FOR-LIKE.
+        # ---------------------------------------------------------------
+        - record: llm:prefill_tokens_per_sec:rate5m
+          expr: |
+            sum by (instance, model) (rate(llamacpp:prompt_tokens_total[5m]))
+            /
+            clamp_min(sum by (instance, model) (rate(llamacpp:prompt_seconds_total[5m])), 0.001)
+
+        # NOTE: uses prompt_tokens_by_source{source="local_compute"}, NOT
+        # prompt_tokens_total. The latter counts prefix-cache HITS too (on this
+        # cluster ~92% of prompt tokens are cache hits), which are never prefilled,
+        # so dividing it by prefill time overstates throughput by ~10x.
+        - record: llm:prefill_tokens_per_sec:rate5m
+          expr: |
+            label_replace(
+              sum by (model_name) (rate(vllm:prompt_tokens_by_source_total{source="local_compute"}[5m]))
+              /
+              clamp_min(sum by (model_name) (rate(vllm:request_prefill_time_seconds_sum[5m])), 0.001)
+            , "model", "$1", "model_name", "(.*)")
+
+        # ---------------------------------------------------------------
+        # Decode (generation) throughput, tokens/sec. LIKE-FOR-LIKE.
+        # ---------------------------------------------------------------
+        - record: llm:decode_tokens_per_sec:rate5m
+          expr: |
+            sum by (instance, model) (rate(llamacpp:tokens_predicted_total[5m]))
+            /
+            clamp_min(sum by (instance, model) (rate(llamacpp:tokens_predicted_seconds_total[5m])), 0.001)
+
+        - record: llm:decode_tokens_per_sec:rate5m
+          expr: |
+            label_replace(
+              1 /
+              clamp_min(
+                sum by (model_name) (rate(vllm:inter_token_latency_seconds_sum[5m]))
+                /
+                clamp_min(sum by (model_name) (rate(vllm:inter_token_latency_seconds_count[5m])), 0.001)
+              , 0.000001)
+            , "model", "$1", "model_name", "(.*)")
+
+        # ---------------------------------------------------------------
+        # Mean prefill seconds per request. Comparable across backends
+        # (both exclude queueing), but NOT normalised for prompt length.
+        # ---------------------------------------------------------------
+        - record: llm:prefill_seconds:avg
+          expr: |
+            label_replace(
+              sum by (model_name) (rate(vllm:request_prefill_time_seconds_sum[5m]))
+              /
+              clamp_min(sum by (model_name) (rate(vllm:request_prefill_time_seconds_count[5m])), 0.001)
+            , "model", "$1", "model_name", "(.*)")
+
+        - record: llm:prefill_seconds:avg
+          expr: |
+            sum by (instance, model) (rate(llamacpp:prompt_seconds_total[5m]))
+            /
+            clamp_min(sum by (instance, model) (rate(llamacpp:n_decode_total[5m])), 0.001)
+
+        # ---------------------------------------------------------------
+        # TRUE TTFT — vLLM only. Includes queueing.
+        # ---------------------------------------------------------------
+        - record: llm:ttft_seconds:p50
+          expr: |
+            label_replace(
+              histogram_quantile(0.50, sum by (le, model_name) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+            , "model", "$1", "model_name", "(.*)")
+
+        - record: llm:ttft_seconds:p95
+          expr: |
+            label_replace(
+              histogram_quantile(0.95, sum by (le, model_name) (rate(vllm:time_to_first_token_seconds_bucket[5m])))
+            , "model", "$1", "model_name", "(.*)")
+
+        - record: llm:ttft_seconds:avg
+          expr: |
+            label_replace(
+              sum by (model_name) (rate(vllm:time_to_first_token_seconds_sum[5m]))
+              /
+              clamp_min(sum by (model_name) (rate(vllm:time_to_first_token_seconds_count[5m])), 0.001)
+            , "model", "$1", "model_name", "(.*)")
+
+        - record: llm:queue_seconds:avg
+          expr: |
+            label_replace(
+              sum by (model_name) (rate(vllm:request_queue_time_seconds_sum[5m]))
+              /
+              clamp_min(sum by (model_name) (rate(vllm:request_queue_time_seconds_count[5m])), 0.001)
+            , "model", "$1", "model_name", "(.*)")
+
+        # ---------------------------------------------------------------
+        # MODELLED TTFT at a fixed 4096-token prompt, both backends.
+        # This is the fair cross-backend number: it removes prompt-length
+        # differences. It is a MODEL, not a measurement, and excludes queueing.
+        # ---------------------------------------------------------------
+        # The `> 1` guard drops idle backends: with no traffic the rate is 0 and
+        # the division would emit a meaningless multi-million-second value.
+        - record: llm:ttft_modelled_seconds:at_4k
+          expr: 4096 / (llm:prefill_tokens_per_sec:rate5m > 1)

--- a/helm/observability/templates/llm-comparison-rules.yaml
+++ b/helm/observability/templates/llm-comparison-rules.yaml
@@ -90,8 +90,13 @@ spec:
             , "model", "$1", "model_name", "(.*)")
 
         # ---------------------------------------------------------------
-        # Mean prefill seconds per request. Comparable across backends
-        # (both exclude queueing), but NOT normalised for prompt length.
+        # Mean prefill seconds per request. vLLM only.
+        #
+        # llama.cpp exposes no per-request prefill counter — only cumulative
+        # prompt_seconds_total and n_decode_total (decode steps, not requests).
+        # Dividing prompt time by n_decode_total yields "prefill seconds per
+        # generated token", not "per request", so no llama.cpp rule is emitted.
+        # Use llm:prefill_tokens_per_sec:rate5m for the cross-backend number.
         # ---------------------------------------------------------------
         - record: llm:prefill_seconds:avg
           expr: |
@@ -100,12 +105,6 @@ spec:
               /
               clamp_min(sum by (model_name) (rate(vllm:request_prefill_time_seconds_count[5m])), 0.001)
             , "model", "$1", "model_name", "(.*)")
-
-        - record: llm:prefill_seconds:avg
-          expr: |
-            sum by (instance, model) (rate(llamacpp:prompt_seconds_total[5m]))
-            /
-            clamp_min(sum by (instance, model) (rate(llamacpp:n_decode_total[5m])), 0.001)
 
         # ---------------------------------------------------------------
         # TRUE TTFT — vLLM only. Includes queueing.

--- a/helm/observability/templates/llm-latency-dashboard.yaml
+++ b/helm/observability/templates/llm-latency-dashboard.yaml
@@ -1,0 +1,734 @@
+{{- /*
+  Grafana dashboard comparing inference latency between the two backends driven
+  from opencode: the Spark/Ray vLLM cluster and pedrogpt (llama.cpp).
+
+  Kept as a standalone ConfigMap rather than an entry in dashboards.yaml because
+  that file's generator emits one expr per panel; this dashboard needs multi-series
+  panels, per-panel units, and explanatory descriptions.
+
+  Grafana legend placeholders are written as {{`{{`}}...{{`}}`}} so Helm passes them
+  through literally instead of trying to evaluate them as template actions.
+
+  Health note: the idle pedrogpt model's scrape target reads DOWN by design.
+  Only one model fits in 32GB VRAM and scrapes pass autoload=false, so Prometheus
+  cannot force-load ~18 GB just to collect metrics.
+*/ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pedro-llm-latency-dashboard
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+  annotations:
+    grafana_folder: Pedro
+data:
+  llm-latency-comparison.json: |
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "graphTooltip": 1,
+      "description": "Compares inference latency between the Spark/Ray vLLM cluster (MiniMax-M2.5-AWQ) and pedrogpt llama.cpp (Qwen3.6-27B-MTP, Qwen3.8-27B), as driven from opencode. NOTE: vLLM reports true TTFT histograms; llama.cpp reports only cumulative counters and has no TTFT metric, so cross-backend TTFT is modelled from prefill throughput at a fixed prompt length.",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 1,
+          "title": "vLLM TTFT (avg, real)",
+          "type": "stat",
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:ttft_seconds:avg",
+              "legendFormat": "{{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "TRUE measured time-to-first-token from vLLM's histogram. Includes queueing.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 2,
+          "title": "vLLM TTFT p95",
+          "type": "stat",
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:ttft_seconds:p95",
+              "legendFormat": "{{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "95th percentile TTFT. vLLM only \u2014 llama.cpp has no equivalent.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 3,
+          "title": "Modelled TTFT @ 4k prompt",
+          "type": "stat",
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 0
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:ttft_modelled_seconds:at_4k",
+              "legendFormat": "{{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "ESTIMATE, both backends. 4096 / prefill_tokens_per_sec. Removes prompt-length differences. Excludes queueing.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 4,
+          "title": "Prefill throughput",
+          "type": "stat",
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 0
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:prefill_tokens_per_sec:rate5m",
+              "legendFormat": "{{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "Tokens/sec during prompt processing. LIKE-FOR-LIKE across backends.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "colorMode": "value",
+            "graphMode": "area"
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 10,
+          "title": "Modelled TTFT @ 4k prompt \u2014 Spark vs pedrogpt",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:ttft_modelled_seconds:at_4k",
+              "legendFormat": "{{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "THE COMPARISON. Both backends normalised to a 4096-token prompt so prompt-length differences do not distort it. This is a MODEL derived from prefill throughput, not a measured TTFT, and excludes queueing on both sides.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 11,
+          "title": "Prefill throughput (tokens/sec)",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:prefill_tokens_per_sec:rate5m",
+              "legendFormat": "{{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "Like-for-like: tokens processed per second during prefill. The underlying quantity behind the modelled TTFT.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 20,
+          "title": "Decode throughput (tokens/sec)",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 0,
+            "y": 13
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:decode_tokens_per_sec:rate5m",
+              "legendFormat": "{{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "Generation speed after the first token. For qwen3.6-27b-mtp this includes the MTP speculative-decoding speedup.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 1
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 21,
+          "title": "vLLM measured TTFT (avg / p50 / p95)",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 9,
+            "w": 12,
+            "x": 12,
+            "y": 13
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:ttft_seconds:avg",
+              "legendFormat": "avg {{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:ttft_seconds:p50",
+              "legendFormat": "p50 {{`{{model}}`}}",
+              "refId": "B",
+              "editorMode": "code",
+              "range": true
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:ttft_seconds:p95",
+              "legendFormat": "p95 {{`{{model}}`}}",
+              "refId": "C",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "Real per-request TTFT \u2014 vLLM only. llama.cpp exposes no TTFT metric, which is why the cross-backend panel uses a model.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 2
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 30,
+          "title": "Mean prefill time per request",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 22
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:prefill_seconds:avg",
+              "legendFormat": "{{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "Comparable across backends (both exclude queueing), but NOT normalised for prompt length \u2014 these models see very different prompt sizes.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 3
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 31,
+          "title": "vLLM queue time (avg)",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 22
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "llm:queue_seconds:avg",
+              "legendFormat": "{{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "Queueing delay on the Ray cluster \u2014 the part of TTFT the llama.cpp model cannot see.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "s",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 3
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "id": 32,
+          "title": "Scrape health",
+          "type": "timeseries",
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 22
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "up{job=~\"llama-cpp|vllm\"}",
+              "legendFormat": "{{`{{job}}`}} {{`{{model}}`}}",
+              "refId": "A",
+              "editorMode": "code",
+              "range": true
+            }
+          ],
+          "description": "EXPECTED: the idle pedrogpt model reads 0. Only one model fits in 32GB VRAM, and scrapes use autoload=false so Prometheus cannot force-load ~18 GB.",
+          "fieldConfig": {
+            "defaults": {
+              "unit": "none",
+              "custom": {
+                "lineWidth": 2,
+                "fillOpacity": 8,
+                "showPoints": "never",
+                "spanNulls": true
+              },
+              "color": {
+                "mode": "palette-classic"
+              },
+              "decimals": 0
+            },
+            "overrides": []
+          },
+          "options": {
+            "legend": {
+              "displayMode": "table",
+              "placement": "bottom",
+              "calcs": [
+                "mean",
+                "max",
+                "lastNotNull"
+              ]
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          }
+        }
+      ],
+      "schemaVersion": 39,
+      "tags": [
+        "pedro-ops",
+        "llm",
+        "latency"
+      ],
+      "templating": {
+        "list": [
+          {
+            "name": "datasource",
+            "type": "datasource",
+            "query": "prometheus",
+            "current": {
+              "text": "Prometheus",
+              "value": "Prometheus"
+            }
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "refresh": "30s",
+      "title": "LLM Latency: Spark vs pedrogpt",
+      "uid": "llm-latency-cmp",
+      "version": 1
+    }

--- a/helm/observability/templates/native-monitors.yaml
+++ b/helm/observability/templates/native-monitors.yaml
@@ -1,0 +1,54 @@
+{{- $root := . -}}
+{{- $monitors := list
+  (dict "namespace" "chatbot" "name" "pedro-twitch" "port" "http")
+  (dict "namespace" "pedro-discord" "name" "pedro-discord" "port" "http")
+-}}
+{{- range $monitors }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+  labels:
+    {{- include "pedro-observability.labels" $root | nindent 4 }}
+spec:
+  namespaceSelector:
+    matchNames: [{{ .namespace }}]
+  selector:
+    matchLabels:
+      {{- if eq .namespace "chatbot" }}
+      app.kubernetes.io/component: twitch
+      app.kubernetes.io/instance: pedro
+      {{- else if eq .namespace "pedro-discord" }}
+      app.kubernetes.io/instance: pedro-discord
+      app.kubernetes.io/name: pedro-discord
+      {{- end }}
+  endpoints:
+    - port: {{ .port }}
+      path: /metrics
+      interval: {{ $root.Values.scrapeInterval }}
+      scrapeTimeout: 10s
+      relabelings:
+        - targetLabel: app
+          replacement: {{ .name }}
+{{- end }}
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: kei-applications
+  namespace: monitoring
+  labels:
+    {{- include "pedro-observability.labels" . | nindent 4 }}
+spec:
+  staticConfigs:
+    - targets: ["abac-engine.kei.svc.cluster.local:80"]
+      labels: {job: kei-abac, namespace: kei, service: abac-engine}
+    - targets: ["oidc-bridge.kei.svc.cluster.local:80"]
+      labels: {job: kei-oidc, namespace: kei, service: oidc-bridge}
+    - targets: ["web.kei.svc.cluster.local:80"]
+      labels: {job: kei-web, namespace: kei, service: web}
+  metricsPath: /metrics
+  scrapeInterval: 30s
+  scrapeTimeout: 10s

--- a/helm/observability/values.yaml
+++ b/helm/observability/values.yaml
@@ -1,0 +1,26 @@
+prometheusRelease: kube-prometheus-stack
+
+images:
+  blackboxExporter: prom/blackbox-exporter:v0.25.0
+  postgresExporter: prometheuscommunity/postgres-exporter:v0.17.1
+  redisExporter: oliver006/redis_exporter:v1.67.0
+
+externalTargets:
+  llama: 100.121.229.114:8000
+  node: 100.121.229.114:9100
+  dcgm: 100.121.229.114:9400
+  openbao: 100.70.90.12:8200
+
+# Models served by llama-server on pedrogpt (router mode). One ScrapeConfig is
+# generated per entry. Keep in sync with scripts/pedrogpt/presets/router.ini —
+# the `name` must match the INI section name exactly (it is the API model id).
+pedrogpt:
+  models:
+    - name: qwen3.6-27b-mtp
+    - name: qwen3.8-27b
+
+discord:
+  secretName: alertmanager-discord
+  secretKey: webhook-url
+
+scrapeInterval: 30s

--- a/helm/observability/values.yaml
+++ b/helm/observability/values.yaml
@@ -7,6 +7,9 @@ images:
 
 externalTargets:
   llama: 100.121.229.114:8000
+  # Ray/vLLM cluster (Spark). Exposes vllm:* metrics including a true
+  # time_to_first_token_seconds histogram.
+  ray: 100.87.122.109:8000
   node: 100.121.229.114:9100
   dcgm: 100.121.229.114:9400
   openbao: 100.70.90.12:8200

--- a/scripts/deploy-observability.sh
+++ b/scripts/deploy-observability.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RELEASE="${OBSERVABILITY_RELEASE:-pedro-observability}"
+NAMESPACE="${MONITORING_NAMESPACE:-monitoring}"
+
+for binary in kubectl helm; do
+  command -v "$binary" >/dev/null || { echo "ERROR: $binary is required" >&2; exit 1; }
+done
+kubectl get nodes >/dev/null
+kubectl -n "$NAMESPACE" get secret alertmanager-discord >/dev/null || {
+  echo "ERROR: $NAMESPACE/alertmanager-discord is missing" >&2
+  echo "Run scripts/sync-discord-alert-secret.sh first." >&2
+  exit 1
+}
+
+helm upgrade --install "$RELEASE" "$REPO_ROOT/helm/observability" \
+  --namespace "$NAMESPACE" --create-namespace --wait --timeout 5m
+kubectl apply -f "$REPO_ROOT/k8s/openwebui/postgres.yaml"
+
+echo "Waiting for Prometheus discovery..."
+sleep 35
+kubectl get servicemonitor,podmonitor,scrapeconfig,probe,prometheusrule,alertmanagerconfig -A \
+  -l app.kubernetes.io/part-of=pedro-observability

--- a/scripts/pedrogpt/README.md
+++ b/scripts/pedrogpt/README.md
@@ -2,14 +2,25 @@
 
 Runtime operations for the llama-server on pedrogpt (100.121.229.114, RTX 5090 / Blackwell sm_120).
 
-The server runs **one dedicated tuned model**: **Qwen3.6-27B with Multi-Token Prediction (MTP)**,
-served under the API id **`qwen3.6-27b-mtp`**. MTP is a self-speculative decoding mode (a draft head
-baked into the GGUF) that gives ~1.4–2.2x faster generation with no quality loss; it requires a single
-request stream (`--parallel 1`), so the box serves exactly one model.
+The server runs in **router mode**, serving **two** models. Callers pick one per request via the
+`"model"` field in `/v1/chat/completions`:
 
-The service is launched by `/opt/llama.cpp/run-server.sh` from `/etc/llama-server.env`
-(see `setup-llama-cpp.sh`). The previous 5-model router was retired — see
-`docs/llama-cpp-build.md` for the build/perf rationale, and `presets/README.md` for the rollback path.
+| API id | Model | MTP | ctx | Resident |
+|---|---|---|---|---|
+| `qwen3.6-27b-mtp` | Qwen3.6-27B-MTP | yes (~1.4–2.2x, no quality loss) | 216064 | loads on startup |
+| `qwen3.8-27b` | Qwen3.8-27B (dense) | no | 131072 | loads on demand |
+
+**Only one is resident at a time.** `qwen3.6-27b-mtp` alone measures 27.9 GB of 32.6 GB VRAM, and two
+27B Q4 models are 35.5 GB of weights before any KV cache — they cannot coexist at any context size.
+`--models-max 1` makes them swap, which costs ~18 GB of I/O on the first request after a switch but
+lets each keep its full context.
+
+MTP requires a single request stream (`--parallel 1`). That is a *per-model* setting and does not
+prevent router mode: each model runs as its own child process.
+
+The service is launched by `/opt/llama.cpp/run-server.sh` from `/etc/llama-server.env`, with
+per-model tuning in `/etc/llama-server-models.ini` (source: `presets/router.ini`). See
+`presets/README.md` for the full flag mapping and `docs/llama-cpp-build.md` for build rationale.
 
 ---
 
@@ -78,15 +89,16 @@ curl http://100.121.229.114:8000/v1/chat/completions \
 #     -d '{"model": "nomic-embed-text", "input": "The quick brown fox"}'
 ```
 
-### Swapping the model later
+### Switching models
 
-Single-model mode has no on-the-fly router. To change the model, update
-`/etc/llama-server.env` and restart — use `switch-model.sh` on the box:
+Nothing to switch server-side: both models are always registered, and naming one in a request loads
+it automatically (evicting the other). Use `switch-model.sh` only to pre-warm before a benchmark or
+to free VRAM:
 
 ```bash
-ssh pedrogpt
-./switch-model.sh download unsloth/Qwen3.6-27B-MTP-GGUF "*UD-Q4_K_XL*" /opt/models/qwen3.6-27b-mtp
-./switch-model.sh /opt/models/qwen3.6-27b-mtp/Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf qwen3.6-27b-mtp
+./switch-model.sh --host pedrogpt list                  # ids + load status
+./switch-model.sh --host pedrogpt load   qwen3.8-27b    # pre-warm (~18 GB, evicts the other)
+./switch-model.sh --host pedrogpt unload qwen3.8-27b    # free VRAM
 ```
 
 ### Embeddings (separate sidecar)
@@ -160,18 +172,31 @@ ssh soypete@100.121.229.114 "sudo journalctl -u llama-server | grep -i 'spec\|dr
 
 ---
 
-## Replacing the model
+## Adding or replacing a model
 
-Single-model mode has no router. To change the served model, swap it in
-`/etc/llama-server.env` and restart — `switch-model.sh` does both (run it on the box):
+Models are declared in `presets/router.ini` (deployed to `/etc/llama-server-models.ini`), so this is
+a config change plus a redeploy — not an env edit:
 
 ```bash
-ssh soypete@100.121.229.114
-# download a new GGUF (prefer an MTP variant for the free speedup)
+# 1. download the GGUF on the box
 ./switch-model.sh download <org>/<model>-GGUF "*UD-Q4_K_XL*" /opt/models/<model-name>
-# activate it (path + API alias); MTP is auto-disabled for non-MTP GGUFs
-./switch-model.sh /opt/models/<model-name>/<file>.gguf <api-alias>
+
+# 2. add a section to scripts/pedrogpt/presets/router.ini
+#      [<api-id>]
+#      model = /opt/models/<model-name>/<file>.gguf
+#      ctx-size = ...
+#    Put MTP flags (spec-type/spec-draft-*) in the section ONLY if that GGUF has a
+#    draft head — inheriting them on a non-MTP model crashes it on load.
+
+# 3. redeploy from your workstation
+./deploy-presets.sh --env /tmp/llama-server.env
+
+# 4. add a Prometheus job for it (?model=<id>&autoload=false) in
+#    llama-cpp-scrapeconfig.yaml and helm/observability/values.yaml
 ```
+
+VRAM, not config, is the binding constraint: a third 27B-class model still means one resident at a
+time and more swap thrash.
 
 When picking a model: check [LiveBench](https://livebench.ai) for scores, find a GGUF on HuggingFace
 (prefer `unsloth`/`bartowski`), size it to leave VRAM for the KV cache (dense up to ~30B at Q4 fits
@@ -193,18 +218,36 @@ ssh soypete@100.121.229.114 "sudo systemctl restart llama-server"
 ssh soypete@100.121.229.114 "cat /etc/llama-server.env; cat /opt/llama.cpp/run-server.sh"
 ```
 
-### Roll back to the old router (5-model) mode
+### Roll back to single-model mode
 
-The router mechanism is retired but recoverable: restore a `--models-preset` drop-in at
-`/etc/systemd/system/llama-server.service.d/preset.conf` pointing at `presets/all-models.ini`,
-`daemon-reload`, and restart. See `presets/README.md` and `git log` for the prior config. Note MTP
-cannot run in router mode (`--parallel 1` only), so rolling back trades the MTP speedup for
-multi-model switching.
+Router mode is selected purely by the ABSENCE of `-m`, so rollback is a file swap. Snapshot before
+deploying, then restore:
+
+```bash
+# snapshot BEFORE any deploy
+ssh pedrogpt 'sudo cp /etc/systemd/system/llama-server.service /root/llama-server.service.bak \
+  && sudo cp /etc/llama-server.env /root/llama-server.env.bak \
+  && sudo cp /opt/llama.cpp/run-server.sh /root/run-server.sh.bak'
+
+# roll back
+ssh pedrogpt 'sudo cp /root/run-server.sh.bak /opt/llama.cpp/run-server.sh \
+  && sudo cp /root/llama-server.env.bak /etc/llama-server.env \
+  && sudo cp /root/llama-server.service.bak /etc/systemd/system/llama-server.service \
+  && sudo rm -f /etc/llama-server-models.ini \
+  && sudo systemctl daemon-reload && sudo systemctl restart llama-server'
+```
+
+Then revert both ScrapeConfigs (drop the `params:` blocks and the second job). The Qwen3.8 GGUF can
+stay on disk — it costs disk, not VRAM.
 
 ### Check Prometheus metrics
 
+In router mode `/metrics` is proxied to the child and **requires** `?model=`; plain `/metrics`
+returns HTTP 400. `/health` is unaffected.
+
 ```bash
-curl http://100.121.229.114:8000/metrics | grep -E 'llama_|requests_'
+curl 'http://100.121.229.114:8000/metrics?model=qwen3.6-27b-mtp&autoload=false' | grep -E 'llamacpp:'
+curl http://100.121.229.114:8000/health
 ```
 
 ### GPU memory usage
@@ -221,8 +264,11 @@ ssh soypete@100.121.229.114 "nvidia-smi --query-gpu=memory.used,memory.free,memo
 |------|-------------|
 | `/opt/llama.cpp/` | llama.cpp build (CUDA 12.8, sm_120) |
 | `/opt/llama.cpp/build/bin/llama-server` | server binary |
-| `/opt/llama.cpp/run-server.sh` | launcher wrapper (reads the env file, assembles MTP/KV flags) |
-| `/opt/models/qwen3.6-27b-mtp/` | the MTP GGUF |
+| `/opt/llama.cpp/run-server.sh` | launcher wrapper (starts the router; no `-m`) |
+| `/opt/models/qwen3.6-27b-mtp/` | Qwen3.6-27B MTP GGUF |
+| `/opt/models/qwen3.8-27b/` | Qwen3.8-27B GGUF |
 | `/etc/systemd/system/llama-server.service` | systemd unit (runs `run-server.sh`) |
-| `/etc/llama-server.env` | runtime config: `MODEL`, `MODEL_ALIAS`, `SPEC_TYPE`, `N_CTX`, sampling, etc. |
-| `scripts/pedrogpt/presets/all-models.ini` | rollback/reference INI for router mode (not used live) |
+| `/etc/llama-server.env` | router config: `MODELS_PRESET`, `MODELS_MAX`, `PORT`, `HF_TOKEN` |
+| `/etc/llama-server-models.ini` | **per-model tuning** (from `presets/router.ini`) |
+| `scripts/pedrogpt/presets/router.ini` | source of truth for the models served |
+| `scripts/pedrogpt/presets/*.ini` (others) | DEPRECATED, retired models, not deployed |

--- a/scripts/pedrogpt/README.md
+++ b/scripts/pedrogpt/README.md
@@ -8,7 +8,7 @@ The server runs in **router mode**, serving **two** models. Callers pick one per
 | API id | Model | MTP | ctx | Resident |
 |---|---|---|---|---|
 | `qwen3.6-27b-mtp` | Qwen3.6-27B-MTP | yes (~1.4–2.2x, no quality loss) | 216064 | loads on startup |
-| `qwen3.8-27b` | Qwen3.8-27B (dense) | no | 131072 | loads on demand |
+| `qwen3.8-27b` | Qwen3.8-27B (dense) | no | 262144 | loads on demand |
 
 **Only one is resident at a time.** `qwen3.6-27b-mtp` alone measures 27.9 GB of 32.6 GB VRAM, and two
 27B Q4 models are 35.5 GB of weights before any KV cache — they cannot coexist at any context size.

--- a/scripts/pedrogpt/benchmark/compare/README.md
+++ b/scripts/pedrogpt/benchmark/compare/README.md
@@ -1,0 +1,87 @@
+# TTFT comparison harness
+
+Measures **client-observed time-to-first-token** across two or more OpenAI-compatible
+backends, using identical prompts and one stopwatch.
+
+```bash
+go run ./compare \
+  -a http://pedrogpt:8000/v1,qwen3.8-27b,pedrogpt/qwen3.8-27b \
+  -b http://100.87.122.109:8000/v1,QuantTrio/MiniMax-M2.5-AWQ,spark/MiniMax-M2.5 \
+  -n 10
+```
+
+Backends are `URL,MODEL[,LABEL]`, repeatable via `-backend`.
+
+## Why client-side rather than Prometheus
+
+Server metrics cannot compare these two backends fairly:
+
+- **vLLM** exposes a true TTFT histogram, but its prefill-derived *throughput* is
+  inflated — `request_prefill_time_seconds` is wall-clock per request while vLLM
+  prefills many requests concurrently, so summing it undercounts compute time.
+- **llama.cpp** exposes **no TTFT metric at all**, only cumulative counters. Any TTFT
+  figure for it has to be modelled from prefill throughput.
+
+Measuring from the client sidesteps both: same prompt, same clock, and it captures what
+a user actually waits for in opencode.
+
+## Field-name gotcha
+
+Thinking models stream reasoning before the answer, and the servers spell it
+differently:
+
+| Server | Field |
+|---|---|
+| llama.cpp | `reasoning_content` |
+| vLLM | `reasoning` |
+
+The tool decodes **both**. Handling only one makes every chunk look empty and the
+backend appear to return nothing — which is exactly what happened on the first run
+here. If you add a third backend and it reports "no content received", check this first.
+
+Both servers also omit the `usage` block from a stream unless asked, so the request
+sets `stream_options.include_usage` — without it, generated-token counts and tok/s
+read zero.
+
+## Reading the results
+
+```
+=== TTFT (client-measured: network + queue + prefill) ===
+backend                               n    p50 ms    p95 ms   mean ms    tok/s
+pedrogpt/qwen3.8-27b                  5      59.5     155.5      83.6     75.3
+spark/MiniMax-M2.5                    5      49.1      50.7      49.4     27.3
+```
+
+**TTFT is load-dependent — do not quote a single run.** Two runs minutes apart gave
+opposite verdicts:
+
+| Run | pedrogpt p50 | Spark p50 | Spark p95 | verdict |
+|---|---|---|---|---|
+| Spark busy | 59.7 ms | 144.7 ms | 442.3 ms | pedrogpt 2.42x faster |
+| Spark idle | 59.5 ms | 49.1 ms | 50.7 ms | Spark 1.21x faster |
+
+pedrogpt was steady at ~59 ms both times; Spark swung between 49 ms and 145 ms
+depending on concurrent traffic. That is a real property of a shared batching server
+versus a single-stream box, not measurement noise — but it means any TTFT claim needs
+the load conditions stated. Run repeatedly, at different times, and report the spread.
+
+**Generation throughput is the stable comparison.** The harness and Prometheus agree
+independently:
+
+| Backend | tok/s (harness) | tok/s (Prometheus) |
+|---|---|---|
+| pedrogpt/qwen3.8-27b | 75.3 | 75.8 |
+| spark/MiniMax-M2.5 | 27.3 | 18.5 |
+
+## Caveats
+
+- TTFT here is the **full** client-observed delay — network (Tailscale), queueing,
+  scheduling and prefill. Honest as a user-facing number, but a slower result does not
+  necessarily mean slower prefill.
+- Comparing a reasoning model against a non-reasoning one is not apples-to-apples
+  however TTFT is measured. Both models here reason by default.
+- pedrogpt runs a router with `--models-max 1`. If the requested model is not resident,
+  the first request pays a ~18 GB load; `-warmup` (default) discards it, but that
+  warmup request itself can take minutes.
+- `-interleave` (default) rotates backends per round so load drift affects both
+  equally. Turn it off only if you want strictly sequential runs.

--- a/scripts/pedrogpt/benchmark/compare/main.go
+++ b/scripts/pedrogpt/benchmark/compare/main.go
@@ -325,9 +325,13 @@ func summarize(backends []backend, results map[string][]runResult) {
 			fmt.Printf("%-30s %8s %9s %9s %9s %8s\n", trunc(be.label, 30), "0", "-", "-", "-", "-")
 			continue
 		}
-		fmt.Printf("%-30s %8d %9.1f %9.1f %9.1f %8.1f\n",
+		tokStr := "-"
+		if len(gen) > 0 {
+			tokStr = fmt.Sprintf("%.1f", mean(gen))
+		}
+		fmt.Printf("%-30s %8d %9.1f %9.1f %9.1f %8s\n",
 			trunc(be.label, 30), len(ttft),
-			percentile(ttft, 50), percentile(ttft, 95), mean(ttft), mean(gen))
+			percentile(ttft, 50), percentile(ttft, 95), mean(ttft), tokStr)
 		if fails > 0 {
 			fmt.Printf("%-30s   (%d request(s) failed)\n", "", fails)
 		}

--- a/scripts/pedrogpt/benchmark/compare/main.go
+++ b/scripts/pedrogpt/benchmark/compare/main.go
@@ -1,0 +1,386 @@
+// Command compare measures time-to-first-token across two OpenAI-compatible
+// inference backends and prints a side-by-side table.
+//
+// # WHY THIS EXISTS
+//
+// The obvious approach — scrape each server's own Prometheus metrics — does not give
+// a fair comparison here:
+//
+//   - vLLM exposes a true TTFT histogram, but its prefill-derived throughput is
+//     inflated: request_prefill_time_seconds is wall-clock per request while vLLM
+//     prefills many requests concurrently in a batch, so summing it undercounts
+//     compute time.
+//   - llama.cpp exposes NO TTFT metric at all — only cumulative counters. Any TTFT
+//     figure for it must be modelled from prefill throughput.
+//
+// Measuring client-side sidesteps both problems: identical prompts, identical
+// measurement, one stopwatch. What the user actually experiences in opencode is the
+// wall-clock delay until the first token appears, which is exactly what this measures.
+//
+// CAVEATS, so the numbers are not oversold:
+//
+//   - This measures the FULL client-observed latency: network (Tailscale), queueing,
+//     scheduling, and prefill. That is the honest user-facing number, but it means a
+//     slower result is not necessarily slower prefill.
+//   - Backends under concurrent load from other users will look worse. Run when idle,
+//     or state the load conditions.
+//   - Reasoning models emit reasoning_content before content. This tool counts the
+//     first token of EITHER as the first token, since that is when output starts
+//     streaming. Comparing a reasoning model against a non-reasoning one is not
+//     apples-to-apples regardless of how TTFT is measured.
+//   - pedrogpt runs a router with --models-max 1. If the requested model is not
+//     resident, the first request pays a ~18 GB load. Use -warmup (default) so that
+//     cost is excluded, and be aware the warmup request itself may take minutes.
+//
+// USAGE
+//
+//	go run ./compare \
+//	  -a http://pedrogpt:8000/v1,qwen3.8-27b \
+//	  -b http://100.87.122.109:8000/v1,QuantTrio/MiniMax-M2.5-AWQ \
+//	  -n 10
+//
+// Any number of backends may be given by repeating -a/-b/-c... or using -backend.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+)
+
+type backend struct {
+	label string
+	url   string
+	model string
+}
+
+// backendList collects repeated -backend flags.
+type backendList []backend
+
+func (b *backendList) String() string { return fmt.Sprint(*b) }
+
+func (b *backendList) Set(v string) error {
+	// form: URL,MODEL[,LABEL]
+	parts := strings.Split(v, ",")
+	if len(parts) < 2 {
+		return fmt.Errorf("want URL,MODEL[,LABEL], got %q", v)
+	}
+	be := backend{url: strings.TrimSpace(parts[0]), model: strings.TrimSpace(parts[1])}
+	if len(parts) > 2 {
+		be.label = strings.TrimSpace(parts[2])
+	} else {
+		be.label = be.model
+	}
+	*b = append(*b, be)
+	return nil
+}
+
+type message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatRequest struct {
+	Model     string    `json:"model"`
+	Messages  []message `json:"messages"`
+	Stream    bool      `json:"stream"`
+	MaxTokens int       `json:"max_tokens"`
+	// Deterministic sampling so repeated runs are comparable.
+	Temperature float64 `json:"temperature"`
+	// Both servers omit the usage block from a stream unless asked, which would
+	// leave the generated-token count (and so tok/s) at zero.
+	StreamOptions streamOptions `json:"stream_options"`
+}
+
+type streamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
+}
+
+// streamChunk covers the fields both llama.cpp and vLLM emit.
+//
+// Thinking models stream their reasoning before the answer, and the two servers spell
+// that field DIFFERENTLY: llama.cpp uses "reasoning_content", vLLM uses "reasoning".
+// Both are decoded here — missing one makes every chunk look empty and the whole
+// backend appear to return nothing at all.
+type streamChunk struct {
+	Choices []struct {
+		Delta struct {
+			Content          string `json:"content"`
+			ReasoningContent string `json:"reasoning_content"`
+			Reasoning        string `json:"reasoning"`
+		} `json:"delta"`
+	} `json:"choices"`
+	Usage *struct {
+		CompletionTokens int `json:"completion_tokens"`
+		PromptTokens     int `json:"prompt_tokens"`
+	} `json:"usage"`
+}
+
+type runResult struct {
+	ttftMS        float64
+	totalMS       float64
+	genTokens     int
+	genPerSec     float64
+	reasonedFirst bool
+	err           error
+}
+
+func main() {
+	var backends backendList
+	flag.Var(&backends, "backend", "backend as URL,MODEL[,LABEL] (repeatable)")
+	a := flag.String("a", "", "shorthand for -backend (first backend)")
+	b := flag.String("b", "", "shorthand for -backend (second backend)")
+	n := flag.Int("n", 10, "measured requests per backend")
+	maxTokens := flag.Int("max-tokens", 64, "max tokens to generate (kept small: TTFT is the target, not throughput)")
+	prompt := flag.String("prompt", "In one sentence, what is a write-ahead log?", "prompt sent to every backend")
+	warmup := flag.Bool("warmup", true, "send one discarded request first (model load / cache warm)")
+	timeout := flag.Duration("timeout", 10*time.Minute, "per-request timeout (generous: a cold router load moves ~18 GB)")
+	interleave := flag.Bool("interleave", true, "rotate backends per round so drift in load affects both equally")
+	flag.Parse()
+
+	for _, s := range []string{*a, *b} {
+		if s != "" {
+			if err := backends.Set(s); err != nil {
+				fmt.Fprintln(os.Stderr, "error:", err)
+				os.Exit(2)
+			}
+		}
+	}
+	if len(backends) < 2 {
+		fmt.Fprintln(os.Stderr, "need at least two backends; see -h")
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	client := &http.Client{Timeout: *timeout}
+
+	fmt.Printf("prompt     : %q\n", *prompt)
+	fmt.Printf("max_tokens : %d   requests: %d   interleave: %v\n\n", *maxTokens, *n, *interleave)
+
+	if *warmup {
+		fmt.Println("warming up (discarded; a cold router load can take minutes)...")
+		for _, be := range backends {
+			r := runOnce(client, be, *prompt, *maxTokens)
+			status := fmt.Sprintf("%.0f ms", r.ttftMS)
+			if r.err != nil {
+				status = "FAILED: " + r.err.Error()
+			}
+			fmt.Printf("  %-28s %s\n", be.label, status)
+		}
+		fmt.Println()
+	}
+
+	results := make(map[string][]runResult, len(backends))
+
+	if *interleave {
+		// Round-robin: any drift in cluster load hits all backends alike.
+		for i := 0; i < *n; i++ {
+			for _, be := range backends {
+				r := runOnce(client, be, *prompt, *maxTokens)
+				results[be.label] = append(results[be.label], r)
+				report1(i+1, be, r)
+			}
+		}
+	} else {
+		for _, be := range backends {
+			for i := 0; i < *n; i++ {
+				r := runOnce(client, be, *prompt, *maxTokens)
+				results[be.label] = append(results[be.label], r)
+				report1(i+1, be, r)
+			}
+		}
+	}
+
+	fmt.Println()
+	summarize(backends, results)
+}
+
+func report1(i int, be backend, r runResult) {
+	if r.err != nil {
+		fmt.Printf("  %2d %-28s ERROR %v\n", i, be.label, r.err)
+		return
+	}
+	note := ""
+	if r.reasonedFirst {
+		note = "  (reasoning first)"
+	}
+	fmt.Printf("  %2d %-28s ttft %7.1f ms | total %8.1f ms | %3d tok | %5.1f tok/s%s\n",
+		i, be.label, r.ttftMS, r.totalMS, r.genTokens, r.genPerSec, note)
+}
+
+func runOnce(client *http.Client, be backend, prompt string, maxTokens int) runResult {
+	body, err := json.Marshal(chatRequest{
+		Model:         be.model,
+		Messages:      []message{{Role: "user", Content: prompt}},
+		Stream:        true,
+		MaxTokens:     maxTokens,
+		Temperature:   0,
+		StreamOptions: streamOptions{IncludeUsage: true},
+	})
+	if err != nil {
+		return runResult{err: err}
+	}
+
+	endpoint := strings.TrimSuffix(be.url, "/") + "/chat/completions"
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return runResult{err: err}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	if err != nil {
+		return runResult{err: err}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return runResult{err: fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))}
+	}
+
+	var res runResult
+	var firstToken time.Time
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+		if data == "[DONE]" {
+			break
+		}
+		var chunk streamChunk
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue // keepalives / partial lines
+		}
+		if firstToken.IsZero() && len(chunk.Choices) > 0 {
+			d := chunk.Choices[0].Delta
+			// Count reasoning too: on a thinking model that is when output actually
+			// starts streaming, and ignoring it would overstate TTFT.
+			reasoning := d.ReasoningContent + d.Reasoning
+			if d.Content != "" || reasoning != "" {
+				firstToken = time.Now()
+				res.reasonedFirst = d.Content == "" && reasoning != ""
+			}
+		}
+		if chunk.Usage != nil && chunk.Usage.CompletionTokens > 0 {
+			res.genTokens = chunk.Usage.CompletionTokens
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return runResult{err: err}
+	}
+
+	res.totalMS = float64(time.Since(start).Microseconds()) / 1000
+	if firstToken.IsZero() {
+		return runResult{err: fmt.Errorf("no content received")}
+	}
+	res.ttftMS = float64(firstToken.Sub(start).Microseconds()) / 1000
+	if gen := res.totalMS - res.ttftMS; gen > 0 && res.genTokens > 0 {
+		res.genPerSec = float64(res.genTokens) / (gen / 1000)
+	}
+	return res
+}
+
+func summarize(backends []backend, results map[string][]runResult) {
+	fmt.Println("=== TTFT (client-measured: network + queue + prefill) ===")
+	fmt.Printf("%-30s %8s %9s %9s %9s %8s\n", "backend", "n", "p50 ms", "p95 ms", "mean ms", "tok/s")
+	fmt.Println(strings.Repeat("-", 78))
+
+	type row struct {
+		label string
+		p50   float64
+	}
+	var rows []row
+
+	for _, be := range backends {
+		rs := results[be.label]
+		var ttft, gen []float64
+		fails := 0
+		for _, r := range rs {
+			if r.err != nil {
+				fails++
+				continue
+			}
+			ttft = append(ttft, r.ttftMS)
+			if r.genPerSec > 0 {
+				gen = append(gen, r.genPerSec)
+			}
+		}
+		if len(ttft) == 0 {
+			fmt.Printf("%-30s %8s %9s %9s %9s %8s\n", trunc(be.label, 30), "0", "-", "-", "-", "-")
+			continue
+		}
+		fmt.Printf("%-30s %8d %9.1f %9.1f %9.1f %8.1f\n",
+			trunc(be.label, 30), len(ttft),
+			percentile(ttft, 50), percentile(ttft, 95), mean(ttft), mean(gen))
+		if fails > 0 {
+			fmt.Printf("%-30s   (%d request(s) failed)\n", "", fails)
+		}
+		rows = append(rows, row{be.label, percentile(ttft, 50)})
+	}
+
+	if len(rows) >= 2 {
+		sort.Slice(rows, func(i, j int) bool { return rows[i].p50 < rows[j].p50 })
+		best, worst := rows[0], rows[len(rows)-1]
+		if best.p50 > 0 {
+			fmt.Printf("\n%s is %.2fx faster to first token than %s (p50).\n",
+				best.label, worst.p50/best.p50, worst.label)
+		}
+	}
+
+	fmt.Println("\nNote: TTFT here is the full client-observed delay — network, queueing and")
+	fmt.Println("prefill — which is what a user feels, but it is not prefill time alone.")
+	fmt.Println("Backends serving other traffic during the run will look worse.")
+}
+
+func trunc(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n-1] + "…"
+}
+
+func mean(v []float64) float64 {
+	if len(v) == 0 {
+		return 0
+	}
+	var s float64
+	for _, x := range v {
+		s += x
+	}
+	return s / float64(len(v))
+}
+
+func percentile(v []float64, p float64) float64 {
+	if len(v) == 0 {
+		return 0
+	}
+	s := append([]float64(nil), v...)
+	sort.Float64s(s)
+	if len(s) == 1 {
+		return s[0]
+	}
+	idx := (p / 100) * float64(len(s)-1)
+	lo := int(math.Floor(idx))
+	hi := int(math.Ceil(idx))
+	if lo == hi {
+		return s[lo]
+	}
+	frac := idx - float64(lo)
+	return s[lo]*(1-frac) + s[hi]*frac
+}

--- a/scripts/pedrogpt/deploy-presets.sh
+++ b/scripts/pedrogpt/deploy-presets.sh
@@ -2,15 +2,17 @@
 
 # Deploy the pedrogpt llama-server config and restart the service.
 #
-# pedrogpt runs a single dedicated Qwen3.6-27B MTP model launched by
-# /opt/llama.cpp/run-server.sh from /etc/llama-server.env. This script:
+# pedrogpt runs llama-server in ROUTER mode (started with no -m/--model), serving two
+# models that swap in and out of VRAM on demand. This script:
 #   1. SCPs run-server.sh (the launcher wrapper) to the box
-#   2. SCPs your env file to /etc/llama-server.env (holds secrets — keep out of git)
-#   3. removes any leftover router/--models-preset drop-in
+#   2. SCPs presets/router.ini to /etc/llama-server-models.ini (per-model tuning)
+#   3. SCPs your env file to /etc/llama-server.env (holds secrets — keep out of git)
 #   4. ensures the systemd unit's ExecStart points at run-server.sh
 #   5. daemon-reload + restart, then health-checks
 #
-# Router/--models-preset mode is retired; the INI in presets/ is a rollback artifact only.
+# Per-model flags live in router.ini, NOT on the llama-server command line: CLI args
+# outrank preset sections and would hit every model (--spec-type would crash the
+# non-MTP model). See presets/README.md for the full flag mapping.
 #
 # NOTE: this uses `ssh -tt` to force a PTY so sudo can prompt for your password.
 # Run it from a real interactive terminal (not a non-interactive wrapper/CI), or it
@@ -32,6 +34,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REMOTE_HOST="pedrogpt"
 REMOTE_ENV_FILE="/etc/llama-server.env"
+REMOTE_PRESET_FILE="/etc/llama-server-models.ini"
 REMOTE_WRAPPER="/opt/llama.cpp/run-server.sh"
 SERVICE_FILE="/etc/systemd/system/llama-server.service"
 SERVICE_NAME="llama-server"
@@ -47,7 +50,7 @@ while [[ $# -gt 0 ]]; do
     --env)     ENV_FILE="$2"; shift 2 ;;
     --restart) RESTART_ONLY=true; shift ;;
     --host)    REMOTE_HOST="$2"; shift 2 ;;
-    -h|--help) head -23 "$0" | tail -20; exit 0 ;;
+    -h|--help) sed -n "3,30p" "$0"; exit 0 ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 done
@@ -61,7 +64,8 @@ echo ""
 if [[ "$RESTART_ONLY" == "false" ]]; then
   if [[ -z "$ENV_FILE" ]]; then
     echo "ERROR: provide --env <file> (the local llama-server.env to deploy) or use --restart."
-    echo "       The env file holds MODEL, MODEL_ALIAS, SPEC_TYPE, N_CTX, HF_TOKEN, etc."
+    echo "       The env file holds MODELS_PRESET, MODELS_MAX, PORT, HF_TOKEN, etc."
+    echo "       Per-model tuning lives in presets/router.ini, not the env file."
     exit 1
   fi
   if [[ ! -f "$ENV_FILE" ]]; then
@@ -69,21 +73,28 @@ if [[ "$RESTART_ONLY" == "false" ]]; then
     exit 1
   fi
 
+  if [[ ! -f "$SCRIPT_DIR/presets/router.ini" ]]; then
+    echo "ERROR: preset not found: $SCRIPT_DIR/presets/router.ini"
+    exit 1
+  fi
+
   echo "--- Copying launcher wrapper -> $REMOTE_HOST:$REMOTE_WRAPPER ---"
   scp "$SCRIPT_DIR/run-server.sh" "$REMOTE_HOST:/tmp/run-server.sh"
+
+  echo "--- Copying router preset -> $REMOTE_HOST:$REMOTE_PRESET_FILE ---"
+  scp "$SCRIPT_DIR/presets/router.ini" "$REMOTE_HOST:/tmp/llama-server-models.ini"
 
   echo "--- Copying $ENV_FILE -> $REMOTE_HOST:$REMOTE_ENV_FILE ---"
   scp "$ENV_FILE" "$REMOTE_HOST:/tmp/llama-server.env"
 
-  # Install wrapper + env, retire the router drop-in, and pin ExecStart to the wrapper.
+  # Install wrapper + preset + env, and pin ExecStart to the wrapper.
   echo "--- Installing on $REMOTE_HOST (sudo — you'll be prompted for your password) ---"
   ssh -tt "$REMOTE_HOST" "sudo install -m 0755 /tmp/run-server.sh $REMOTE_WRAPPER \
     && sudo install -m 0600 /tmp/llama-server.env $REMOTE_ENV_FILE \
-    && sudo rm -f /etc/systemd/system/${SERVICE_NAME}.service.d/preset.conf \
-    && sudo rmdir /etc/systemd/system/${SERVICE_NAME}.service.d 2>/dev/null || true \
+    && sudo install -m 0644 /tmp/llama-server-models.ini $REMOTE_PRESET_FILE \
     && printf '%s\n' \
         '[Unit]' \
-        'Description=llama.cpp Server' \
+        'Description=llama.cpp Server (router: qwen3.6-27b-mtp + qwen3.8-27b)' \
         'After=network-online.target' \
         'Wants=network-online.target' \
         '' \
@@ -92,14 +103,15 @@ if [[ "$RESTART_ONLY" == "false" ]]; then
         'ExecStart=/opt/llama.cpp/run-server.sh' \
         'Restart=on-failure' \
         'RestartSec=10' \
+        'TimeoutStopSec=120' \
         'SyslogIdentifier=llama-server' \
         'SupplementaryGroups=render video' \
         '' \
         '[Install]' \
         'WantedBy=multi-user.target' \
       | sudo tee $SERVICE_FILE >/dev/null \
-    && rm -f /tmp/run-server.sh /tmp/llama-server.env"
-  echo "  Wrapper, env, and unit installed; router drop-in removed."
+    && rm -f /tmp/run-server.sh /tmp/llama-server.env /tmp/llama-server-models.ini"
+  echo "  Wrapper, preset, env, and unit installed."
   echo ""
 fi
 
@@ -114,7 +126,8 @@ if ssh -tt "$REMOTE_HOST" "sudo systemctl is-active --quiet $SERVICE_NAME"; then
   echo ""
   echo "=== $SERVICE_NAME active on $REMOTE_HOST ==="
   echo "Health:  curl http://$REMOTE_HOST:8000/health"
-  echo "Models:  curl http://$REMOTE_HOST:8000/v1/models | jq '.data[].id'   # -> qwen3.6-27b-mtp"
+  echo "Models:  curl http://$REMOTE_HOST:8000/v1/models | jq '.data[].id'   # -> qwen3.6-27b-mtp, qwen3.8-27b"
+  echo "Metrics: curl '"'"'http://$REMOTE_HOST:8000/metrics?model=qwen3.6-27b-mtp&autoload=false'"'"'"
   echo "Logs:    ssh $REMOTE_HOST sudo journalctl -u $SERVICE_NAME -f"
 else
   echo "ERROR: $SERVICE_NAME failed to start"

--- a/scripts/pedrogpt/llama-cpp-scrapeconfig.yaml
+++ b/scripts/pedrogpt/llama-cpp-scrapeconfig.yaml
@@ -1,4 +1,4 @@
-# SUPERSEDED — prefer the Helm chart. This file and
+# SUPERSEDED — DO NOT APPLY alongside the Helm chart. This file and
 # helm/observability/templates/external-scrapes.yaml define the SAME targets with the
 # SAME labels. Applying both double-counts every series in sum() queries.
 #
@@ -6,6 +6,9 @@
 # .Values.pedrogpt.models, so adding a model is a values edit). Keep this standalone
 # file only for a cluster without the chart installed; if you apply it, first run:
 #   kubectl delete scrapeconfig -n monitoring pedrogpt-qwen3-6-27b-mtp pedrogpt-qwen3-8-27b
+#
+# This actually happened on 2026-08-20: both were live simultaneously (llama-cpp-* from
+# this file, pedrogpt-* from the chart) until the llama-cpp-* pair was deleted.
 #
 # ScrapeConfig for llama.cpp running on pedrogpt (external to k8s cluster).
 #

--- a/scripts/pedrogpt/llama-cpp-scrapeconfig.yaml
+++ b/scripts/pedrogpt/llama-cpp-scrapeconfig.yaml
@@ -1,7 +1,19 @@
 # ScrapeConfig for llama.cpp running on pedrogpt (external to k8s cluster).
 #
-# pedrogpt runs a single dedicated model (Qwen3.6-27B MTP), so one ScrapeConfig
-# is sufficient. (Router mode, which needed a ?model= param per model, is retired.)
+# pedrogpt runs llama-server in ROUTER mode serving two models, so there is one
+# ScrapeConfig per model.
+#
+# In router mode /metrics is PROXIED to the child model process and REQUIRES a
+# ?model=<id> query param — without it the endpoint returns HTTP 400
+# "model name is missing from the request". Hence the `params` block below.
+#
+# autoload=false is deliberate and important: only one model is resident at a time
+# (--models-max 1, ~18 GB each). Without this flag a 15s scrape of the *idle* model
+# would force-load it, evicting the other, and Prometheus would thrash the GPU
+# permanently. The idle model's scrape failing is CORRECT behaviour, not an outage —
+# expect one of these two jobs to be down at any given time.
+#
+# /health needs no ?model= and stays a plain router-level check.
 #
 # Apply to the monitoring namespace:
 #   kubectl apply -f llama-cpp-scrapeconfig.yaml
@@ -22,6 +34,7 @@ metadata:
   name: llama-cpp-qwen3-6-27b-mtp
   namespace: monitoring
   labels:
+    release: kube-prometheus-stack
     app.kubernetes.io/name: llama-cpp
     app.kubernetes.io/instance: pedrogpt
     app.kubernetes.io/component: llm-server
@@ -34,5 +47,37 @@ spec:
         instance: pedrogpt
         model: qwen3.6-27b-mtp
   metricsPath: /metrics
-  scrapeInterval: 30s
+  params:
+    model:
+      - "qwen3.6-27b-mtp"
+    autoload:
+      - "false"
+  scrapeInterval: 15s
+  scrapeTimeout: 15s
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ScrapeConfig
+metadata:
+  name: llama-cpp-qwen3-8-27b
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+    app.kubernetes.io/name: llama-cpp
+    app.kubernetes.io/instance: pedrogpt
+    app.kubernetes.io/component: llm-server
+spec:
+  staticConfigs:
+    - targets:
+        - "100.121.229.114:8000"
+      labels:
+        job: llama-cpp
+        instance: pedrogpt
+        model: qwen3.8-27b
+  metricsPath: /metrics
+  params:
+    model:
+      - "qwen3.8-27b"
+    autoload:
+      - "false"
+  scrapeInterval: 15s
   scrapeTimeout: 15s

--- a/scripts/pedrogpt/llama-cpp-scrapeconfig.yaml
+++ b/scripts/pedrogpt/llama-cpp-scrapeconfig.yaml
@@ -1,3 +1,12 @@
+# SUPERSEDED — prefer the Helm chart. This file and
+# helm/observability/templates/external-scrapes.yaml define the SAME targets with the
+# SAME labels. Applying both double-counts every series in sum() queries.
+#
+# The chart is the source of truth (it generates one job per entry in
+# .Values.pedrogpt.models, so adding a model is a values edit). Keep this standalone
+# file only for a cluster without the chart installed; if you apply it, first run:
+#   kubectl delete scrapeconfig -n monitoring pedrogpt-qwen3-6-27b-mtp pedrogpt-qwen3-8-27b
+#
 # ScrapeConfig for llama.cpp running on pedrogpt (external to k8s cluster).
 #
 # pedrogpt runs llama-server in ROUTER mode serving two models, so there is one
@@ -53,7 +62,7 @@ spec:
     autoload:
       - "false"
   scrapeInterval: 15s
-  scrapeTimeout: 15s
+  scrapeTimeout: 10s
 ---
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: ScrapeConfig
@@ -80,4 +89,4 @@ spec:
     autoload:
       - "false"
   scrapeInterval: 15s
-  scrapeTimeout: 15s
+  scrapeTimeout: 10s

--- a/scripts/pedrogpt/llama-server.env.example
+++ b/scripts/pedrogpt/llama-server.env.example
@@ -7,46 +7,29 @@
 #
 # NEVER commit a copy with a real HF_TOKEN — this .example is the only version in git.
 # read by run-server.sh; edit on the box + `sudo systemctl restart llama-server` also works.
+#
+# ROUTER MODE: model paths, context sizes, sampling, and all per-model tuning now live in
+# the preset INI (see MODELS_PRESET below), NOT in this file. Editing this file no longer
+# changes model tuning — edit scripts/pedrogpt/presets/router.ini and redeploy instead.
 
-# Local GGUF path (the MTP head is baked into this checkpoint — no separate draft model).
-MODEL=/opt/models/qwen3.6-27b-mtp/Qwen3.6-27B-UD-Q4_K_XL.gguf
+# Model preset INI defining every servable model. Source: scripts/pedrogpt/presets/router.ini
+MODELS_PRESET=/etc/llama-server-models.ini
 
-# API model id advertised at /v1/models. Downstream repos (SuperAgentPedro, iam_pedro,
-# pedro-bots) send this exact id — do not rename without coordinating.
-MODEL_ALIAS=qwen3.6-27b-mtp
+# Max models resident in VRAM at once. MUST stay 1: measured 27.9 GB / 32.6 GB for
+# qwen3.6-27b-mtp alone, and two 27B Q4 models are 35.5 GB of weights before any KV
+# cache. Raising this will OOM the GPU. Past this limit the router LRU-evicts.
+MODELS_MAX=1
+
+# Autoload a model when a request names one that is not resident (1 = on).
+# With MODELS_MAX=1 this is what makes model switching work at all.
+MODELS_AUTOLOAD=1
 
 # HuggingFace cache directory (on the 2TB drive)
 HF_HOME=/opt/models/cache
 
-# GPU layers (-1 = all layers on GPU; the dense 27B fits fully in 32GB VRAM)
-N_GPU_LAYERS=-1
-
-# Context window (tokens). Qwen3.6's hybrid DeltaNet/GQA layout keeps the KV cache
-# small even at 200k+ with q8_0 quantization.
-N_CTX=216064
-
-# Parallel request slots — MUST be 1 for MTP.
-N_PARALLEL=1
-
-# Batch sizes: -b logical token budget, -ub physical micro-batch shipped to the GPU.
-BATCH=2048
-UBATCH=1024
-
-# MTP self-speculative decoding. SPEC_DRAFT_N = max draft tokens per step.
-SPEC_TYPE=draft-mtp
-SPEC_DRAFT_N=2
-
-# KV cache quantization (q8_0 halves KV VRAM). Requires flash-attn; K and V must match.
-# run-server.sh also applies these to the MTP draft head cache.
-CACHE_TYPE_K=q8_0
-CACHE_TYPE_V=q8_0
-
-# Sampling (Unsloth non-thinking recommendation for Qwen3.6).
-TEMP=0.7
-TOP_K=20
-TOP_P=0.8
-PRESENCE_PENALTY=1.5
-MIN_P=0.0
+# Destination for llama.cpp's own `-hf` pulls. Outranks HF_HOME for that purpose
+# (common/hf-cache.cpp). Set explicitly so the download path is stated, not inferred.
+LLAMA_CACHE=/opt/models/cache/llama.cpp
 
 # Server port (Tailscale serve maps this to HTTPS)
 PORT=8000

--- a/scripts/pedrogpt/llama-server.service
+++ b/scripts/pedrogpt/llama-server.service
@@ -1,12 +1,15 @@
 # llama-server systemd unit for pedrogpt (RTX 5090 / Blackwell sm_120).
 #
 # Source of truth for /etc/systemd/system/llama-server.service on pedrogpt —
-# deployed by deploy-presets.sh (scp or taildrop). All launch flags live in
-# /opt/llama.cpp/run-server.sh + /etc/llama-server.env, so this unit rarely
-# changes: edit the env file for tuning, edit run-server.sh for new flags.
+# deployed by deploy-presets.sh (scp or taildrop). Launch flags live in
+# /opt/llama.cpp/run-server.sh + /etc/llama-server.env, and PER-MODEL tuning lives in
+# /etc/llama-server-models.ini, so this unit rarely changes.
+#
+# Runs llama-server in router mode: this process serves no model itself, it spawns a
+# child process per model on demand (--models-max 1, so they swap).
 
 [Unit]
-Description=llama.cpp Server (Qwen3.6-27B MTP)
+Description=llama.cpp Server (router: qwen3.6-27b-mtp + qwen3.8-27b)
 Documentation=https://github.com/Soypete/pedro-ops
 After=network-online.target
 Wants=network-online.target
@@ -16,6 +19,8 @@ Type=simple
 ExecStart=/opt/llama.cpp/run-server.sh
 Restart=on-failure
 RestartSec=10
+# A model swap unloads ~18 GB and loads another; give children room to exit cleanly.
+TimeoutStopSec=120
 SyslogIdentifier=llama-server
 SupplementaryGroups=render video
 

--- a/scripts/pedrogpt/presets/README.md
+++ b/scripts/pedrogpt/presets/README.md
@@ -115,6 +115,59 @@ Roll back the `ctx-size` if it OOMs or if free VRAM drops below ~1 GB.
 > Because `--models-max 1` means each model has the whole card to itself, context is bounded by the
 > single largest model, not by the sum. Adding a third model does not shrink anyone's context.
 
+## Reasoning / thinking control
+
+Two **different** mechanisms are easy to confuse:
+
+| | `--reasoning-budget N` | `reasoning_effort` |
+|---|---|---|
+| Kind | llama.cpp CLI flag / preset key | key inside `chat-template-kwargs` |
+| Type | **integer only** — `-1`, `0`, or `N>0` | **keyword** — model-defined |
+| Values | `-1` unrestricted (default), `0` end immediately, `N` cap at N tokens | see below |
+| Enforced by | llama.cpp's sampler — a hard stop | the model's Jinja template |
+
+`--reasoning-budget` rejects anything below `-1` (`common/arg.cpp`) and does **not** accept
+`low`/`medium`/`high`. Passing a keyword there fails to parse. Related flags: `-rea, --reasoning
+on|off|auto` (a plain switch) and `--reasoning-format` (where thoughts are returned, not whether
+they happen).
+
+`reasoning_effort` is passed straight through to the model — llama.cpp neither validates nor
+interprets it — so **the valid values are defined by the model's chat template**, which is why no
+list appears in llama.cpp's docs.
+
+### Values this box's models accept
+
+**`qwen3.8-27b`** — its embedded template accepts exactly three, and raises
+`Unexpected reasoning effort ... Supported types are xhigh (default), medium, and low.` on anything
+else:
+
+| Value | Notes |
+|---|---|
+| `xhigh` | **the template's default** — maximum effort |
+| `medium` | **what we set** — good latency/quality trade |
+| `low` | brief, focused thinking |
+
+`high` is accepted but **silently remapped onto `xhigh`**, so it is not a distinct tier — which is
+why advice to prefer "medium or max" over "high/xhigh" holds here: there is no separate `high` to gain from.
+
+Left unset, this model reasons at `xhigh` on **every** request. That is worth knowing because it
+makes short-`max_tokens` calls appear to return an empty reply: the whole budget is consumed by
+thinking, and the content field comes back empty while `reasoning_content` is populated. We set
+`medium` explicitly in `router.ini`.
+
+**`qwen3.6-27b-mtp`** disables thinking outright with `chat-template-kwargs =
+{"enable_thinking":false}` — a Qwen-template-specific key that predates `reasoning_effort`.
+
+To inspect what any GGUF supports, read its embedded template:
+
+```bash
+# dump tokenizer.chat_template from the GGUF and grep for the key
+llama-gguf /opt/models/<model>/<file>.gguf r n | grep -i chat_template
+```
+
+Reference: `tools/server/README.md` (the `--chat-template-kwargs` flag, and the per-request
+`chat_template_kwargs` body field) and `docs/preset.md` for the INI form.
+
 ## Metrics changed under router mode
 
 `/metrics` is proxied to the child and **requires** `?model=<id>`, else HTTP 400

--- a/scripts/pedrogpt/presets/README.md
+++ b/scripts/pedrogpt/presets/README.md
@@ -1,64 +1,175 @@
 # llama.cpp Model Presets
 
-pedrogpt (RTX 5090, sm_120, 32GB VRAM, 64GB RAM) runs **one dedicated tuned model**:
-**Qwen3.6-27B with Multi-Token Prediction (MTP)**.
+pedrogpt (RTX 5090, sm_120, 32GB VRAM, 64GB RAM) runs `llama-server` in **router mode**, serving
+**two** models that **swap in and out of VRAM on demand**.
 
-The live server is launched by `/opt/llama.cpp/run-server.sh` from `/etc/llama-server.env`
-(installed by `setup-llama-cpp.sh`) — a single-model invocation, **not** router/`--models-preset`
-mode. MTP requires a single stream (`parallel = 1`) and cannot coexist with multi-slot batching, so
-the box serves exactly one model.
+The live config is **`router.ini`** in this directory, deployed to `/etc/llama-server-models.ini` by
+`deploy-presets.sh`. Every other `.ini` here is marked `DEPRECATED` and is not read by anything.
 
-`all-models.ini` in this directory is kept only as a **rollback / reference artifact** describing the
-MTP model for router mode; it is not what the running service reads.
+| Section / API id | Model | Quant | MTP | ctx | Loads on startup |
+|---|---|---|---|---|---|
+| `qwen3.6-27b-mtp` | Qwen3.6-27B-MTP | UD-Q4_K_XL (~17.9 GB) | yes (baked-in head) | 216064 | yes |
+| `qwen3.8-27b` | Qwen3.8-27B | UD-Q4_K_XL (17.56 GB) | no | 262144 (full native) | no |
 
-> History: this box previously ran a 5-model router (GLM-4.7-Flash, Nemotron-3-Super-120B,
-> Qwen3-Next-80B, Qwen2.5-VL-32B, plain Qwen3.6-27B). Those were retired in favor of the single fast
-> MTP model. See `git log` and `docs/llama-cpp-build.md` for the rationale.
+Callers pass the id in the `"model"` field of `/v1/chat/completions`. `qwen3.6-27b-mtp` is unchanged
+from single-model mode, so existing callers (OpenWebUI, `benchmark/`, SuperAgentPedro, iam_pedro,
+pedro-bots) need no changes.
 
-## The model
+## How router mode works
 
-| Section | Model | Quant | Type | Notes |
-|---------|-------|-------|------|-------|
-| `qwen3.6-27b-mtp` | Qwen3.6-27B-MTP | UD-Q4_K_XL (~17.9 GB) | Dense + MTP head | self-speculative decoding, `parallel=1` |
+`llama-server` is started **without `-m`/`--model`** — that absence is what selects router mode. The
+router process serves no model itself and never touches the GPU; it spawns **one child process per
+model** on demand, and each child inherits the router's environment plus its own preset section.
 
-API model id: **`qwen3.6-27b-mtp`** (set via `--alias`). Callers pass it in the `"model"` field.
+Because children are separate processes, per-model settings genuinely stay per-model. That is why
+`parallel = 1` (required by MTP) on one model does not constrain the other.
 
-## Downloading the model
+## Where each flag lives
 
-```bash
-hf download unsloth/Qwen3.6-27B-MTP-GGUF \
-  --include "*UD-Q4_K_XL*" \
-  --local-dir /opt/models/qwen3.6-27b-mtp
+Single-model mode passed every flag on one command line. Router mode splits them three ways. This
+table maps the old `run-server.sh` invocation onto the new layout — use it when something seems
+"missing":
+
+| Flag | Now lives in | Applies to |
+|---|---|---|
+| `--jinja` | `[*]` in `router.ini` | **both models** — needed for tool calls |
+| `--no-webui` | `[*]` | both |
+| `--metrics` | `[*]` | both (router proxies `/metrics` to the child) |
+| `--flash-attn on` | `[*]` | both (also a prerequisite for q8_0 KV cache) |
+| `--host`, `--port` | `run-server.sh` | router process |
+| `--models-preset`, `--models-max`, `--models-autoload` | `run-server.sh` / env file | router process |
+| `-m` / `--model` | section `model =` key | per model |
+| `--alias` | the **section name** is the API id | per model |
+| `--ctx-size` | section | per model |
+| `--n-gpu-layers`, `--parallel` | section | per model |
+| `--batch-size`, `--ubatch-size` | section | per model |
+| `--mlock` | section | **model 1 only** (see below) |
+| `--cache-type-k` / `-v` | section | per model |
+| `--spec-type`, `--spec-draft-n-max` | section | **model 1 only** |
+| `--cache-type-k-draft` / `-v-draft` | section | model 1 only |
+| `--temp`, `--top-k`, `--top-p`, `--presence-penalty`, `--min-p` | section | per model |
+| `--chat-template-kwargs` | section | model 1 |
+
+Preset-only keys (not command-line flags): `load-on-startup`, `stop-timeout`.
+
+Precedence, highest first: **CLI args** → **model section** → **`[*]`**.
+
+> **Do not add per-model tuning flags to `run-server.sh`.** CLI args outrank preset sections and hit
+> *every* model. `--spec-type` there would crash the non-MTP model on load.
+
+### Why `spec-type` and `mlock` are not in `[*]`
+
+- **`spec-type = draft-mtp`** — Qwen3.8-27B has no draft head. Inheriting this flag makes that child
+  fail on load. MTP flags belong only to `qwen3.6-27b-mtp`.
+- **`mlock`** — locking 17.5 GB of a model that is designed to be evicted fights the swap. Only the
+  startup model locks its weights.
+
+## VRAM: why the models swap instead of coexisting
+
+Measured on the box, single model loaded:
+
+```
+$ nvidia-smi --query-compute-apps=pid,process_name,used_memory --format=csv
+1737, /opt/llama.cpp/build/bin/llama-server, 27952 MiB
+$ nvidia-smi --query-gpu=memory.total,memory.free --format=csv
+32607 MiB, 4104 MiB
 ```
 
-Q5_K_M (~19.8 GB) is the fallback if more quality headroom is wanted — both fit 32GB VRAM alongside
-the MTP head and a q8_0 KV cache.
+`qwen3.6-27b-mtp` at ctx 216064 uses **27.9 GB of 32.6 GB**, leaving 4.1 GB. Model 2's weights alone
+are 17.56 GB.
 
-## Tuning reference (set in /etc/llama-server.env)
+Reducing context does not rescue it: **17.9 + 17.56 = 35.5 GB of weights exceeds the 32.6 GB card
+before a single KV byte**. Two 27B Q4 models cannot be co-resident on this GPU at any context size.
 
-| Setting | Value | Why |
-|---------|-------|-----|
-| `-ngl 99` | all layers on GPU | dense 27B fits fully; any CPU layer tanks throughput |
-| `-fa on` | flash attention | faster + prerequisite for KV-cache quantization |
-| `--cache-type-k/v q8_0` | quantized KV | ~halves KV VRAM; **K and V must match** or attention falls back to a slow path |
-| `-ub 1024` | micro-batch | larger ubatch improves prefill; safe on a 5090 |
-| `-np 1` | single slot | **required** by MTP |
-| `--spec-type draft-mtp --spec-draft-n-max 3` | enable MTP | self-speculative decoding, ~1.4–2.2x, no quality loss |
+Hence `--models-max 1`. The upside: since only one model is ever resident, **each keeps its full
+context** — there was no need to shrink the 216k window.
 
-> Confirm the exact spec-type spelling for your build: `llama-server --help | grep -i spec`.
-> Some builds spell it `mtp` rather than `draft-mtp`.
+**The tradeoff is swap latency.** Each switch unloads ~18 GB and reads ~18 GB from disk, so the first
+request after switching models stalls noticeably (tens of seconds cold). Steady-state throughput on
+either model is unaffected. `load-on-startup = true` on the MTP model means the default model is hot
+after a restart and only the secondary pays a cold start.
 
-## Finding a future replacement model
+## Context sizing
 
-1. **Check [LiveBench](https://livebench.ai/#/?highunseenbias=true)** — enable "High Unseen Bias",
-   sort by Overall or category.
-2. **Find a GGUF on [HuggingFace](https://huggingface.co)** — prefer `unsloth` or `bartowski`. For a
-   dense model on 32GB VRAM, `Q4_K_M`/`UD-Q4_K_XL` up to ~30B leaves room for KV cache.
-3. **Prefer an MTP GGUF** when available — the built-in draft head gives a free speedup.
+Both models are trained to **262144** tokens (`n_ctx_train`).
 
-| Quant | Quality | Notes |
-|-------|---------|-------|
-| UD-Q4_K_XL | Excellent | unsloth dynamic 4-bit, recommended |
-| Q5_K_M | Very good | more headroom, still fits |
-| Q6_K | Excellent | ~22.9 GB, tighter KV budget |
-| Q8_0 | Near-lossless | ~29 GB, small context only |
+`qwen3.8-27b` runs at the **full 262144**. That is affordable because only **16 of its 64 layers use
+full attention** (`full_attention_interval = 4`; the other 48 are `linear_attention` and carry no
+growing KV cache). With 4 KV heads x 256 head_dim and `q8_0` K/V, KV at 262144 is **~8.6 GB**, against
+a ~15 GB budget (32.6 GB card - 17.56 GB weights).
+
+`qwen3.6-27b-mtp` runs at **216064**, below its 262144 training window — this is why the log shows
+`n_ctx_seq (216064) < n_ctx_train (262144) -- the full capacity of the model will not be utilized`.
+Raising it is **unverified**: measured usage is 27.95 GB at 216064, so extrapolating the non-weight
+cost (~46.5 MB per 1k tokens) puts 262144 at **~30.1 GB of 32.6 GB — only ~2.5 GB headroom**.
+
+To test it, change `ctx-size` in that section, redeploy, and watch the load:
+
+```bash
+ssh pedrogpt 'nvidia-smi --query-gpu=memory.used,memory.free --format=csv'
+ssh pedrogpt 'journalctl -u llama-server -n 50 --no-pager | grep -i "cuda\|buffer\|error"'
+```
+
+Roll back the `ctx-size` if it OOMs or if free VRAM drops below ~1 GB.
+
+> Because `--models-max 1` means each model has the whole card to itself, context is bounded by the
+> single largest model, not by the sum. Adding a third model does not shrink anyone's context.
+
+## Metrics changed under router mode
+
+`/metrics` is proxied to the child and **requires** `?model=<id>`, else HTTP 400
+(`model name is missing from the request`):
+
+```bash
+curl 'http://pedrogpt:8000/metrics?model=qwen3.6-27b-mtp&autoload=false'
+```
+
+`autoload=false` matters: without it, a 15s Prometheus scrape of the *idle* model would force-load
+18 GB and thrash the GPU permanently. The idle model's scrape failing is correct behaviour, not an
+outage. Both ScrapeConfigs (`../llama-cpp-scrapeconfig.yaml` and
+`helm/observability/templates/external-scrapes.yaml`) set these params.
+
+**`/health` is unaffected** and needs no `?model=` — it stays a plain router-level check.
+
+## Managing models at runtime
+
+```bash
+curl -s http://pedrogpt:8000/v1/models | jq '.data[].id'     # list + load status
+../switch-model.sh load   qwen3.8-27b                        # POST /models/load
+../switch-model.sh unload qwen3.6-27b-mtp                    # POST /models/unload
+```
+
+## Downloading the models
+
+```bash
+hf download unsloth/Qwen3.6-27B-MTP-GGUF --include "*UD-Q4_K_XL*" \
+  --local-dir /opt/models/qwen3.6-27b-mtp
+hf download unsloth/Qwen3.8-27B-GGUF --include "Qwen3.8-27B-UD-Q4_K_XL.gguf" \
+  --local-dir /opt/models/qwen3.8-27b
+```
+
+Models are pre-downloaded to local paths rather than resolved via `-hf` at boot: with
+`Restart=on-failure`, a start that blocks on a 17.5 GB fetch turns a network blip into a retry loop.
+
+> Qwen3.8-27B has an MTP draft head available *separately* as `MTP/mtp-Qwen3.8-27B-Q4_0.gguf`
+> (1.37 GB). It is **not** baked into the Q4_K_XL file. Wiring it up would need `spec-type` plus
+> `spec-draft-model` in that section — deliberately not done.
+
+## Adding a third model
+
+VRAM is the binding constraint, not config: a third 27B-class model still means one resident at a
+time and more swap thrash. If it is small (≤10 GB) consider a second `llama-server` on port 8001
+instead, so both stay hot.
+
+Otherwise: add a section to `router.ini`, download the GGUF, add a ScrapeConfig job with
+`?model=<id>&autoload=false`, and redeploy.
+
+## Historical note
+
+This box previously ran a 5-model router (GLM-4.7-Flash, Nemotron-3-Super-120B, Qwen3-Next-80B,
+Qwen2.5-VL-32B, plain Qwen3.6-27B), then a single-model MTP server. The deprecated `.ini` files here
+describe those retired models.
+
+Earlier revisions of this README stated that MTP "cannot run in router mode." **That was wrong** —
+it conflated `parallel > 1` (which MTP does preclude) with router mode itself. Router children are
+separate processes, so `parallel = 1` is preserved per-model.

--- a/scripts/pedrogpt/presets/all-models.ini
+++ b/scripts/pedrogpt/presets/all-models.ini
@@ -1,3 +1,10 @@
+# DEPRECATED — NOT DEPLOYED. Kept for reference/rollback only.
+# Superseded by router.ini, which defines the two live models
+# (qwen3.6-27b-mtp + qwen3.8-27b) actually served in router mode.
+#
+# The live config is scripts/pedrogpt/presets/router.ini, deployed to
+# /etc/llama-server-models.ini by deploy-presets.sh. Nothing reads this file.
+#
 # llama.cpp model preset — Qwen3.6-27B MTP (single dedicated model)
 # Hardware: 32GB VRAM (RTX 5090, sm_120) + 64GB RAM
 #

--- a/scripts/pedrogpt/presets/code.ini
+++ b/scripts/pedrogpt/presets/code.ini
@@ -1,3 +1,9 @@
+# DEPRECATED — NOT DEPLOYED. Kept for reference/rollback only.
+# Describes retired MoE models (Qwen3-Next-80B, Qwen3-Coder-30B).
+#
+# The live config is scripts/pedrogpt/presets/router.ini, deployed to
+# /etc/llama-server-models.ini by deploy-presets.sh. Nothing reads this file.
+#
 # llama.cpp model preset: Coding model
 # Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
 #

--- a/scripts/pedrogpt/presets/router.ini
+++ b/scripts/pedrogpt/presets/router.ini
@@ -1,0 +1,102 @@
+# llama.cpp router-mode presets for pedrogpt (RTX 5090, sm_120, 32GB VRAM / 64GB RAM).
+#
+# Deployed to /etc/llama-server-models.ini by deploy-presets.sh.
+#
+# Router mode: llama-server is started WITHOUT -m/--model, so that process loads no
+# model and never touches the GPU. Each section below is spawned as its own child
+# llama-server process, inheriting the router's environment. Per-model flags therefore
+# belong in a section, NOT in [*] — see the MTP note below for why that matters.
+#
+# VRAM: measured 27.9 GB / 32.6 GB for qwen3.6-27b-mtp alone at ctx 216064. Two 27B Q4
+# models are 35.5 GB of weights before any KV cache, so they cannot be co-resident on a
+# 32GB card at ANY context size. The unit sets --models-max 1 and models swap on demand.
+# Because only one is ever resident, each keeps its full context.
+#
+# Cost of that choice: switching models unloads ~18 GB and reads ~18 GB off disk, so the
+# first request after a switch stalls noticeably. Steady-state speed is unaffected.
+
+# NOTE: deliberately no `version = 1` line here. Any key placed above the first section
+# header is parsed into an implicit section and registers a phantom model named
+# "default", which then shows up in /v1/models and in OpenWebUI's model picker and fails
+# when selected. Verified on build b9802; upstream's docs/preset.md omits it too.
+# The deprecated INIs in this directory still carry it — do not copy them.
+
+# Shared defaults ONLY. Anything model-specific belongs in a section below.
+# --metrics must reach each child: the router proxies /metrics to the child process.
+[*]
+flash-attn = on
+no-webui   = true
+metrics    = true
+jinja      = true
+
+# ---------------------------------------------------------------------------
+# Model 1 — Qwen3.6-27B, MTP draft head baked into the GGUF.
+#
+# The section name is the API id. It is deliberately unchanged from single-model mode
+# so every existing caller keeps working untouched: OpenWebUI (discovers via /v1/models),
+# scripts/pedrogpt/benchmark, SuperAgentPedro, iam_pedro, pedro-bots.
+#
+# MTP note: spec-type/spec-draft-* live HERE and must never move to [*]. Qwen3.8 has no
+# draft head, and inheriting these flags would crash that child on load.
+# parallel = 1 is required by MTP and is preserved per-model — router children are
+# separate processes, so this does not constrain the other model.
+# ---------------------------------------------------------------------------
+#
+# Context headroom: this model is trained to 262144 (n_ctx_train) but runs at 216064,
+# leaving 46080 tokens unused — hence the startup warning "n_ctx_seq (216064) <
+# n_ctx_train (262144)". Raising it is plausible but NOT yet verified: measured usage
+# is 27.95 GB at 216064, and extrapolating the non-weight cost (~46.5 MB per 1k tok)
+# puts 262144 at ~30.1 GB of 32.6 GB — only ~2.5 GB headroom. Measure before raising;
+# an OOM here takes down the primary model.
+[qwen3.6-27b-mtp]
+model                = /opt/models/qwen3.6-27b-mtp/Qwen3.6-27B-UD-Q4_K_XL.gguf
+ctx-size             = 216064
+n-gpu-layers         = -1
+parallel             = 1
+batch-size           = 2048
+ubatch-size          = 1024
+mlock                = true
+cache-type-k         = q8_0
+cache-type-v         = q8_0
+spec-type            = draft-mtp
+spec-draft-n-max     = 2
+cache-type-k-draft   = q8_0
+cache-type-v-draft   = q8_0
+temp                 = 0.7
+top-k                = 20
+top-p                = 0.8
+presence-penalty     = 1.5
+min-p                = 0.0
+chat-template-kwargs = {"enable_thinking":false}
+load-on-startup      = true
+
+# ---------------------------------------------------------------------------
+# Model 2 — Qwen3.8-27B (dense, 17.56 GB), unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_XL.
+#
+# NOT an MTP model: the Q4_K_XL file has no draft head baked in (upstream ships one
+# separately as MTP/mtp-Qwen3.8-27B-Q4_0.gguf). No spec-type here by design.
+#
+# No mlock: this is the model that gets evicted, and locking 17.5 GB fights the swap.
+# Pre-downloaded to a local path rather than resolved via -hf at boot, so a systemd
+# start never blocks on a 17.56 GB fetch under Restart=on-failure.
+# ---------------------------------------------------------------------------
+[qwen3.8-27b]
+#
+# Context: 262144 is this model's full native window (config.json
+# max_position_embeddings). It is affordable because only 16 of 64 layers use full
+# attention (full_attention_interval = 4; the other 48 are linear_attention and carry
+# no growing KV cache). With 4 KV heads x 256 head_dim and q8_0 K/V, KV at 262144 is
+# ~8.6 GB against a ~15 GB budget (32.6 GB card - 17.56 GB weights).
+model            = /opt/models/qwen3.8-27b/Qwen3.8-27B-UD-Q4_K_XL.gguf
+ctx-size         = 262144
+n-gpu-layers     = -1
+parallel         = 1
+batch-size       = 2048
+ubatch-size      = 1024
+cache-type-k     = q8_0
+cache-type-v     = q8_0
+temp             = 0.7
+top-k            = 20
+top-p            = 0.8
+min-p            = 0.0
+load-on-startup  = false

--- a/scripts/pedrogpt/presets/router.ini
+++ b/scripts/pedrogpt/presets/router.ini
@@ -95,6 +95,12 @@ batch-size       = 2048
 ubatch-size      = 1024
 cache-type-k     = q8_0
 cache-type-v     = q8_0
+# Reasoning effort. This model's own chat template accepts exactly three values —
+# xhigh (its DEFAULT), medium, low — and raises on anything else. ('high' is silently
+# remapped onto xhigh, so it is not a distinct tier.) Left unset the model reasons at
+# xhigh on every request, which is why short max_tokens replies can come back empty:
+# the whole budget goes to thinking. medium trades a little depth for latency.
+chat-template-kwargs = {"reasoning_effort": "medium"}
 temp             = 0.7
 top-k            = 20
 top-p            = 0.8

--- a/scripts/pedrogpt/presets/text.ini
+++ b/scripts/pedrogpt/presets/text.ini
@@ -1,3 +1,9 @@
+# DEPRECATED — NOT DEPLOYED. Kept for reference/rollback only.
+# Describes retired models (GPT-OSS-20B, Nemotron-3-Super-120B).
+#
+# The live config is scripts/pedrogpt/presets/router.ini, deployed to
+# /etc/llama-server-models.ini by deploy-presets.sh. Nothing reads this file.
+#
 # llama.cpp model preset: General-purpose text model
 # Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
 #

--- a/scripts/pedrogpt/presets/tts.ini
+++ b/scripts/pedrogpt/presets/tts.ini
@@ -1,3 +1,9 @@
+# DEPRECATED — NOT DEPLOYED. Kept for reference/rollback only.
+# Describes a retired TTS model (Qwen2.5-Omni-7B); never deployed in router mode.
+#
+# The live config is scripts/pedrogpt/presets/router.ini, deployed to
+# /etc/llama-server-models.ini by deploy-presets.sh. Nothing reads this file.
+#
 # llama.cpp model preset: Text-to-Speech (TTS) model
 # Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
 #

--- a/scripts/pedrogpt/presets/vision.ini
+++ b/scripts/pedrogpt/presets/vision.ini
@@ -1,3 +1,9 @@
+# DEPRECATED — NOT DEPLOYED. Kept for reference/rollback only.
+# Describes retired vision models (Qwen2.5-VL 32B/7B).
+#
+# The live config is scripts/pedrogpt/presets/router.ini, deployed to
+# /etc/llama-server-models.ini by deploy-presets.sh. Nothing reads this file.
+#
 # llama.cpp model preset: Vision (text + image) model
 # Hardware: 32GB VRAM (RTX 5090) + 64GB RAM
 #

--- a/scripts/pedrogpt/run-server.sh
+++ b/scripts/pedrogpt/run-server.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
-# llama-server launcher — reads /etc/llama-server.env and starts the tuned
-# Qwen3.6-27B MTP single-model server. Called by the llama-server systemd service.
+# llama-server launcher — reads /etc/llama-server.env and starts llama-server in
+# ROUTER mode. Called by the llama-server systemd service.
+#
+# Router mode is selected by the ABSENCE of -m/--model: this process loads no model and
+# does not touch the GPU. Models are declared in $MODELS_PRESET, and each is spawned as
+# its own child llama-server process on demand, inheriting this process's environment.
+# Per-model tuning therefore lives in the preset INI, not here.
 #
 # Source of truth: this file is deployed to /opt/llama.cpp/run-server.sh by
 # deploy-presets.sh (and installed by setup-llama-cpp.sh). Edit it here, then deploy.
@@ -11,47 +16,37 @@ ENV_FILE="/etc/llama-server.env"
 source "$ENV_FILE"
 
 export HF_HOME="${HF_HOME:-/opt/models/cache}"
+# Explicit: LLAMA_CACHE outranks HF_HOME for llama.cpp's own -hf pulls
+# (common/hf-cache.cpp). Stating it means the download path never depends on the
+# export ordering above.
+export LLAMA_CACHE="${LLAMA_CACHE:-/opt/models/cache/llama.cpp}"
 export HUGGING_FACE_HUB_TOKEN="${HF_TOKEN:-}"
+
+MODELS_PRESET="${MODELS_PRESET:-/etc/llama-server-models.ini}"
+if [[ ! -f "$MODELS_PRESET" ]]; then
+  echo "ERROR: models preset not found: $MODELS_PRESET" >&2
+  echo "       Deploy it with: ./deploy-presets.sh --env <env-file>" >&2
+  exit 1
+fi
 
 EXTRA_ARGS=()
 
-# MTP self-speculative decoding (no separate draft model — the head is in the GGUF).
-if [[ -n "${SPEC_TYPE:-}" ]]; then
-  EXTRA_ARGS+=(--spec-type "${SPEC_TYPE}" --spec-draft-n-max "${SPEC_DRAFT_N:-3}")
+# Autoload a model when a request names one that is not resident.
+# With MODELS_MAX=1 this is what makes model switching work at all.
+if [[ "${MODELS_AUTOLOAD:-1}" == "1" ]]; then
+  EXTRA_ARGS+=(--models-autoload)
+else
+  EXTRA_ARGS+=(--no-models-autoload)
 fi
 
-# Quantized KV cache (requires flash-attn; K and V must match).
-if [[ -n "${CACHE_TYPE_K:-}" ]]; then
-  EXTRA_ARGS+=(--cache-type-k "${CACHE_TYPE_K}" --cache-type-v "${CACHE_TYPE_V:-$CACHE_TYPE_K}")
-fi
-
-# Embeddings endpoint — opt-in only. Enabling it builds an embeddings output graph
-# that is incompatible with some models / the MTP spec-decoding graph and will
-# crash the server on load (GGML_ASSERT "missing result_norm/result_embd tensor").
-# Leave EMBEDDINGS unset for a chat-completions-only server.
-if [[ "${EMBEDDINGS:-}" == "1" ]]; then
-  EXTRA_ARGS+=(--embeddings --pooling "${POOLING:-mean}")
-fi
-
+# NOTE: no -m/--model here — that is what selects router mode.
+#
+# Do NOT add per-model tuning flags below. CLI args outrank preset sections and would be
+# applied to EVERY model: --spec-type in particular would crash the non-MTP model.
+# Add such flags to the model's section in $MODELS_PRESET instead.
 exec /opt/llama.cpp/build/bin/llama-server \
     --host 0.0.0.0 \
     --port "${PORT:-8000}" \
-    -m "${MODEL}" \
-    --alias "${MODEL_ALIAS:-qwen3.6-27b-mtp}" \
-    --ctx-size "${N_CTX:-65536}" \
-    --n-gpu-layers "${N_GPU_LAYERS:-99}" \
-    --parallel "${N_PARALLEL:-1}" \
-    --batch-size "${BATCH:-2048}" \
-    --ubatch-size "${UBATCH:-1024}" \
-    --flash-attn on \
-    --mlock \
-    --jinja \
-    --no-webui \
-    --metrics \
-    --temp "${TEMP:-0.7}" \
-    --top-k "${TOP_K:-20}" \
-    --top-p "${TOP_P:-0.8}" \
-    --presence-penalty "${PRESENCE_PENALTY:-1.5}" \
-    --min-p "${MIN_P:-0.0}" \
-    --chat-template-kwargs '{"enable_thinking":false}' \
+    --models-preset "$MODELS_PRESET" \
+    --models-max "${MODELS_MAX:-1}" \
     "${EXTRA_ARGS[@]}"

--- a/scripts/pedrogpt/setup-llama-cpp.sh
+++ b/scripts/pedrogpt/setup-llama-cpp.sh
@@ -2,7 +2,7 @@
 
 # Setup llama.cpp on Ubuntu (pedrogpt) with CUDA support.
 # Builds llama-server and installs it as a systemd service that
-# exposes Prometheus metrics at :8000/metrics.
+# exposes Prometheus metrics at :8000/metrics?model=<id> (router mode requires the param).
 #
 # Usage: ./setup-llama-cpp-ubuntu.sh [--rebuild]
 #   --rebuild  Force a clean rebuild even if llama.cpp is already installed
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LLAMA_DIR="/opt/llama.cpp"
 MODEL_DIR="/opt/models"
 ENV_FILE="/etc/llama-server.env"
+MODELS_PRESET_PATH="/etc/llama-server-models.ini"
 SERVICE_FILE="/etc/systemd/system/llama-server.service"
 PORT=8000
 
@@ -185,54 +186,30 @@ echo "Use ./switch-model.sh to download and activate a model."
 if [[ ! -f "$ENV_FILE" ]]; then
   echo "--- Creating $ENV_FILE ---"
   sudo tee "$ENV_FILE" > /dev/null <<'EOF'
-# llama-server runtime configuration — dedicated Qwen3.6-27B MTP single-model server.
+# llama-server runtime configuration — ROUTER mode (two models, one resident).
 # Edit this file then: sudo systemctl restart llama-server
 #
-# This box runs ONE tuned model with Multi-Token Prediction (MTP) self-speculative
-# decoding. MTP requires a single stream (N_PARALLEL=1) — it cannot share VRAM with
-# multi-slot continuous batching. Router/preset mode is retired (kept as rollback only).
+# Per-model tuning (GGUF paths, ctx, sampling, MTP flags) lives in the preset INI
+# below, NOT here. Source of truth: scripts/pedrogpt/presets/router.ini in pedro-ops,
+# deployed by deploy-presets.sh. See presets/README.md for the full flag mapping.
 
-# Local GGUF path (downloaded by switch-model.sh / hf download). The MTP head is baked
-# into this checkpoint, so no separate draft model is needed.
-MODEL=/opt/models/qwen3.6-27b-mtp/Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf
+# Model preset INI defining every servable model.
+MODELS_PRESET=/etc/llama-server-models.ini
 
-# API model id advertised at /v1/models and required in request "model" fields.
-MODEL_ALIAS=qwen3.6-27b-mtp
+# Max models resident in VRAM at once. MUST stay 1: qwen3.6-27b-mtp alone measures
+# 27.9 GB of 32.6 GB, and two 27B Q4 models are 35.5 GB of weights before any KV cache.
+# Raising this will OOM the GPU. Past this limit the router LRU-evicts.
+MODELS_MAX=1
+
+# Autoload a model when a request names one that is not resident (1 = on).
+# With MODELS_MAX=1 this is what makes model switching work at all.
+MODELS_AUTOLOAD=1
 
 # HuggingFace cache directory (on the 2TB drive)
 HF_HOME=/opt/models/cache
 
-# GPU layers (99 = all layers on GPU; the dense 27B fits fully in 32GB VRAM)
-N_GPU_LAYERS=99
-
-# Context window (tokens). 65536 fits alongside Q4 weights + MTP head + q8_0 KV cache.
-# Qwen3.6's hybrid DeltaNet/GQA layout keeps the KV cache small; 131072 also fits if needed.
-N_CTX=65536
-
-# Parallel request slots — MUST be 1 for MTP.
-N_PARALLEL=1
-
-# Batch sizes: -b logical token budget, -ub physical micro-batch shipped to the GPU.
-# Larger UBATCH improves prompt-processing (prefill) throughput; 1024 is safe on a 5090.
-BATCH=2048
-UBATCH=1024
-
-# MTP self-speculative decoding. SPEC_DRAFT_N = max draft tokens per step (start 2, try 3).
-# Confirm the exact spec-type spelling for your build: llama-server --help | grep -i spec
-SPEC_TYPE=draft-mtp
-SPEC_DRAFT_N=3
-
-# KV cache quantization (q8_0 halves KV VRAM at negligible quality cost). Requires flash-attn.
-# K and V MUST match or llama.cpp silently falls back to the slow attention path.
-CACHE_TYPE_K=q8_0
-CACHE_TYPE_V=q8_0
-
-# Sampling (Unsloth non-thinking recommendation for Qwen3.6).
-TEMP=0.7
-TOP_K=20
-TOP_P=0.8
-PRESENCE_PENALTY=1.5
-MIN_P=0.0
+# Destination for llama.cpp's own `-hf` pulls. Outranks HF_HOME for that purpose.
+LLAMA_CACHE=/opt/models/cache/llama.cpp
 
 # Server port (Tailscale serve maps this to HTTPS)
 PORT=8000
@@ -243,12 +220,13 @@ EOF
   echo "Edit $ENV_FILE before starting the service."
 else
   echo "--- $ENV_FILE already exists, skipping ---"
-  echo "    (single-model MTP mode reads MODEL/MODEL_ALIAS/SPEC_TYPE etc. — see the template above"
-  echo "     if upgrading from router/MoE mode, replace the old env file)"
+  echo "    (router mode reads MODELS_PRESET/MODELS_MAX/MODELS_AUTOLOAD — see the template above."
+  echo "     If upgrading from single-model mode, the old MODEL/MODEL_ALIAS/SPEC_TYPE/N_CTX vars"
+  echo "     are no longer read; per-model tuning moved to \$MODELS_PRESET.)"
 fi
 
 # ---------------------------------------------------------------------------
-# Wrapper script — launches the dedicated Qwen3.6-27B MTP single-model server.
+# Wrapper script — launches llama-server in router mode (no -m; models from the preset INI).
 # Installed from the committed run-server.sh (single source of truth, also used
 # by deploy-presets.sh). Reads /etc/llama-server.env.
 # ---------------------------------------------------------------------------
@@ -289,20 +267,30 @@ echo ""
 echo "=== Setup complete ==="
 echo ""
 echo "Next steps:"
-echo "  1. Download the MTP model (~18 GB to /opt/models/qwen3.6-27b-mtp):"
+echo "  1. Download both models (~18 GB each):"
 echo "       hf download unsloth/Qwen3.6-27B-MTP-GGUF --include '*UD-Q4_K_XL*' \\"
 echo "         --local-dir /opt/models/qwen3.6-27b-mtp"
-echo "     Then set MODEL= in $ENV_FILE to the downloaded .gguf path."
+echo "       hf download unsloth/Qwen3.8-27B-GGUF --include 'Qwen3.8-27B-UD-Q4_K_XL.gguf' \\"
+echo "         --local-dir /opt/models/qwen3.8-27b"
+echo "     Paths must match the model= keys in the preset INI (step 2)."
 echo ""
-echo "  2. Confirm the MTP flag spelling matches this build:"
-echo "       $LLAMA_DIR/build/bin/llama-server --help | grep -i spec"
+echo "  2. Deploy the router preset — the server will NOT start without it:"
+echo "       # from a checkout of pedro-ops, on your workstation:"
+echo "       ./scripts/pedrogpt/deploy-presets.sh --env /tmp/llama-server.env"
+echo "     That installs presets/router.ini to $MODELS_PRESET_PATH."
 echo ""
-echo "  3. Start the server:"
+echo "  3. Confirm this build has router support and the MTP flag spelling:"
+echo "       $LLAMA_DIR/build/bin/llama-server --help | grep -E -- '--models|spec-type'"
+echo ""
+echo "  4. Start the server:"
 echo "       sudo systemctl start llama-server"
 echo "       sudo systemctl status llama-server"
 echo ""
-echo "  4. Verify it's serving the MTP model and metrics:"
-echo "       curl http://localhost:8000/v1/models | jq '.data[].id'   # -> qwen3.6-27b-mtp"
-echo "       curl http://localhost:8000/metrics | head -20"
+echo "  5. Verify both models are registered and metrics work:"
+echo "       curl http://localhost:8000/v1/models | jq '.data[].id'"
+echo "         # -> qwen3.6-27b-mtp, qwen3.8-27b"
+echo "       curl http://localhost:8000/health                        # 200, no ?model= needed"
+echo "       curl 'http://localhost:8000/metrics?model=qwen3.6-27b-mtp&autoload=false' | head"
+echo "         # NOTE: plain /metrics returns HTTP 400 in router mode — ?model= is required"
 echo ""
 echo "  Logs: sudo journalctl -u llama-server -f"

--- a/scripts/pedrogpt/setup-metrics-exporters.sh
+++ b/scripts/pedrogpt/setup-metrics-exporters.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run on pedrogpt. Publishes host and GPU metrics on the Tailscale address only.
+set -euo pipefail
+
+TS_IP="${PEDROGPT_TS_IP:-100.121.229.114}"
+NODE_IMAGE="${NODE_EXPORTER_IMAGE:-quay.io/prometheus/node-exporter:v1.8.2}"
+DCGM_IMAGE="${DCGM_EXPORTER_IMAGE:-nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04}"
+
+command -v docker >/dev/null || { echo "ERROR: docker is required" >&2; exit 1; }
+ip -4 addr show tailscale0 | grep -Fq "$TS_IP" || {
+  echo "ERROR: $TS_IP is not assigned to tailscale0" >&2
+  exit 1
+}
+
+docker pull "$NODE_IMAGE"
+docker pull "$DCGM_IMAGE"
+docker rm -f pedrogpt-node-exporter pedrogpt-dcgm-exporter 2>/dev/null || true
+docker run -d --name pedrogpt-node-exporter --restart unless-stopped \
+  --network host --pid host \
+  -v /:/host:ro \
+  "$NODE_IMAGE" --path.rootfs=/host --web.listen-address="$TS_IP:9100"
+
+if [ ! -x /usr/bin/nvidia-cuda-mps-control ]; then
+  echo "ERROR: /usr/bin/nvidia-cuda-mps-control is missing; DCGM cannot start with this NVIDIA runtime." >&2
+  echo "Install the driver-matched nvidia-compute-utils package, then rerun this script." >&2
+  exit 1
+fi
+docker run -d --name pedrogpt-dcgm-exporter --restart unless-stopped \
+  --gpus all --cap-add SYS_ADMIN \
+  -p "$TS_IP:9400:9400" "$DCGM_IMAGE"
+
+curl --fail --silent "http://$TS_IP:9100/metrics" >/dev/null
+curl --fail --silent "http://$TS_IP:9400/metrics" >/dev/null
+echo "pedrogpt node and GPU exporters are healthy on Tailscale"

--- a/scripts/pedrogpt/switch-model.sh
+++ b/scripts/pedrogpt/switch-model.sh
@@ -1,31 +1,64 @@
 #!/bin/bash
 
-# Switch the active model on pedrogpt (single-model mode).
+# Manage the models served by llama-server on pedrogpt (ROUTER mode).
 #
-# pedrogpt runs ONE tuned model launched by /opt/llama.cpp/run-server.sh from
-# /etc/llama-server.env. This script updates MODEL (the local GGUF path) and
-# MODEL_ALIAS (the API id) in that env file, then restarts llama-server.
+# Router mode changes what "switching" means. There is no longer an active model to
+# swap: both models are always registered and callers pick one per request via the
+# "model" field in /v1/chat/completions. This script only controls which is RESIDENT
+# in VRAM.
 #
-# Run this ON pedrogpt (it edits /etc/llama-server.env directly).
+# Because --models-max 1 (two 27B Q4 models do not fit in 32GB together), loading one
+# model evicts the other. Each swap unloads ~18 GB and reads ~18 GB from disk, so the
+# first request after a switch stalls noticeably.
 #
-# Current model: Qwen3.6-27B MTP (qwen3.6-27b-mtp) — has a built-in MTP draft head,
-# enabled via SPEC_TYPE=draft-mtp in the env file. No separate draft model needed.
+# You usually do NOT need this script: with --models-autoload, naming a model in a
+# request loads it automatically. Use this to pre-warm a model before a benchmark, or
+# to free VRAM.
+#
+# Models are defined in presets/router.ini and deployed by deploy-presets.sh. To add or
+# retune a model, edit that INI and redeploy — not this script.
+#
+# Runs from anywhere with access to the server (defaults to localhost; use --host).
 #
 # Usage:
-#   ./switch-model.sh <gguf-path> <api-alias>
-#   ./switch-model.sh download <hf-repo> <include-glob> <local-dir>   # fetch a new GGUF
+#   ./switch-model.sh list                        # models + load status
+#   ./switch-model.sh load   <model-id>           # load into VRAM (evicts the other)
+#   ./switch-model.sh unload <model-id>           # free VRAM
+#   ./switch-model.sh download <hf-repo> <include-glob> <local-dir>
+#   ./switch-model.sh --host pedrogpt list
 #
 # Examples:
-#   ./switch-model.sh /opt/models/qwen3.6-27b-mtp/Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf qwen3.6-27b-mtp
-#   ./switch-model.sh download unsloth/Qwen3.6-27B-MTP-GGUF "*UD-Q4_K_XL*" /opt/models/qwen3.6-27b-mtp
+#   ./switch-model.sh load qwen3.8-27b
+#   ./switch-model.sh download unsloth/Qwen3.8-27B-GGUF "Qwen3.8-27B-UD-Q4_K_XL.gguf" /opt/models/qwen3.8-27b
 
 set -euo pipefail
 
-ENV_FILE="/etc/llama-server.env"
+HOST="localhost"
+PORT="8000"
+
+# Allow --host/--port before the subcommand.
+while [[ "${1:-}" == --* ]]; do
+  case "$1" in
+    --host) HOST="$2"; shift 2 ;;
+    --port) PORT="$2"; shift 2 ;;
+    -h|--help) sed -n "3,33p" "$0"; exit 0 ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+BASE="http://${HOST}:${PORT}"
 SUBCOMMAND="${1:-}"
 
+usage() {
+  echo "Usage: $0 [--host H] [--port P] list"
+  echo "       $0 [--host H] [--port P] load   <model-id>"
+  echo "       $0 [--host H] [--port P] unload <model-id>"
+  echo "       $0 download <hf-repo> <include-glob> <local-dir>"
+}
+
 # ---------------------------------------------------------------------------
-# download: fetch a GGUF into /opt/models
+# download: fetch a GGUF into /opt/models (does NOT register it — add a section
+# to presets/router.ini and redeploy for the router to serve it)
 # ---------------------------------------------------------------------------
 if [[ "$SUBCOMMAND" == "download" ]]; then
   HF_REPO="${2:-}"; INCLUDE="${3:-}"; LOCAL_DIR="${4:-}"
@@ -35,61 +68,72 @@ if [[ "$SUBCOMMAND" == "download" ]]; then
   fi
   echo "=== Downloading $HF_REPO ($INCLUDE) -> $LOCAL_DIR ==="
   hf download "$HF_REPO" --include "$INCLUDE" --local-dir "$LOCAL_DIR"
-  echo "Done. Activate it with: $0 <gguf-path> <api-alias>"
+  echo ""
+  echo "Downloaded. To serve it:"
+  echo "  1. add a section to presets/router.ini with model = $LOCAL_DIR/<file>.gguf"
+  echo "  2. ./deploy-presets.sh --env <your-env-file>"
   exit 0
 fi
 
 # ---------------------------------------------------------------------------
-# switch: update MODEL/MODEL_ALIAS and restart
+# list / load / unload
 # ---------------------------------------------------------------------------
-MODEL_PATH="${1:-}"
-MODEL_ALIAS="${2:-}"
+case "$SUBCOMMAND" in
+  list)
+    echo "=== Models on $BASE ==="
+    if ! curl -sf --max-time 10 "$BASE/v1/models" > /tmp/.models.$$ 2>/dev/null; then
+      echo "ERROR: cannot reach $BASE/v1/models"
+      rm -f /tmp/.models.$$
+      exit 1
+    fi
+    python3 -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+rows = d.get("data", [])
+if not rows:
+    print("  (no models registered)")
+for m in rows:
+    status = (m.get("status") or {}).get("value", "unknown")
+    print("  %-24s %s" % (m.get("id", "?"), status))
+' /tmp/.models.$$
+    rm -f /tmp/.models.$$
+    ;;
 
-if [[ -z "$MODEL_PATH" || -z "$MODEL_ALIAS" ]]; then
-  echo "Usage: $0 <gguf-path> <api-alias>"
-  echo "       $0 download <hf-repo> <include-glob> <local-dir>"
-  echo ""
-  echo "Example:"
-  echo "  $0 /opt/models/qwen3.6-27b-mtp/Qwen3.6-27B-MTP-UD-Q4_K_XL.gguf qwen3.6-27b-mtp"
-  exit 1
-fi
+  load|unload)
+    MODEL_ID="${2:-}"
+    if [[ -z "$MODEL_ID" ]]; then
+      echo "ERROR: $SUBCOMMAND requires a model id."
+      echo ""
+      usage
+      exit 1
+    fi
+    echo "=== ${SUBCOMMAND}ing $MODEL_ID ==="
+    if [[ "$SUBCOMMAND" == "load" ]]; then
+      echo "(with --models-max 1 this evicts the other model; expect ~18 GB of I/O)"
+    fi
+    if curl -sf --max-time 600 -X POST "$BASE/models/$SUBCOMMAND" \
+         -H 'Content-Type: application/json' \
+         -d "{\"model\":\"$MODEL_ID\"}" > /dev/null; then
+      echo "OK."
+      echo ""
+      "$0" --host "$HOST" --port "$PORT" list
+    else
+      echo "ERROR: $SUBCOMMAND failed for '$MODEL_ID'."
+      echo "       Check the id is a section name in presets/router.ini:"
+      echo "         $0 --host $HOST list"
+      exit 1
+    fi
+    ;;
 
-if [[ ! -f "$ENV_FILE" ]]; then
-  echo "ERROR: $ENV_FILE not found. Run setup-llama-cpp.sh first."
-  exit 1
-fi
+  ""|help|-h|--help)
+    usage
+    exit 0
+    ;;
 
-if [[ ! -f "$MODEL_PATH" ]]; then
-  echo "WARNING: $MODEL_PATH not found on disk. Download it first with: $0 download ..."
-fi
-
-echo "=== Switching model ==="
-echo "MODEL:       $MODEL_PATH"
-echo "MODEL_ALIAS: $MODEL_ALIAS"
-echo ""
-
-# If this model has no MTP head, disable MTP to avoid a startup error.
-if [[ "$MODEL_PATH" != *MTP* && "$MODEL_PATH" != *mtp* ]]; then
-  echo "NOTE: '$MODEL_PATH' doesn't look like an MTP GGUF — clearing SPEC_TYPE so the"
-  echo "      server doesn't try to enable MTP on a model without a draft head."
-  sudo sed -i "s|^SPEC_TYPE=.*|SPEC_TYPE=|" "$ENV_FILE"
-fi
-
-sudo sed -i "s|^MODEL=.*|MODEL=$MODEL_PATH|" "$ENV_FILE"
-sudo sed -i "s|^MODEL_ALIAS=.*|MODEL_ALIAS=$MODEL_ALIAS|" "$ENV_FILE"
-
-echo "Updated $ENV_FILE. Restarting llama-server..."
-sudo systemctl restart llama-server
-sleep 5
-
-if sudo systemctl is-active --quiet llama-server; then
-  echo ""
-  echo "=== Active model: $MODEL_ALIAS ==="
-  echo "Health:  curl http://localhost:8000/health"
-  echo "Models:  curl http://localhost:8000/v1/models | jq '.data[].id'"
-  echo "Logs:    sudo journalctl -u llama-server -f"
-else
-  echo "ERROR: llama-server failed to start"
-  sudo journalctl -u llama-server -n 30
-  exit 1
-fi
+  *)
+    echo "ERROR: unknown subcommand '$SUBCOMMAND'"
+    echo ""
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/pedrogpt/switch-model.sh
+++ b/scripts/pedrogpt/switch-model.sh
@@ -66,8 +66,16 @@ if [[ "$SUBCOMMAND" == "download" ]]; then
     echo "Usage: $0 download <hf-repo> <include-glob> <local-dir>"
     exit 1
   fi
-  echo "=== Downloading $HF_REPO ($INCLUDE) -> $LOCAL_DIR ==="
-  hf download "$HF_REPO" --include "$INCLUDE" --local-dir "$LOCAL_DIR"
+  # The model must land on the machine running llama-server, not on your laptop.
+  # list/load/unload talk to $BASE over HTTP and work from anywhere, but downloading
+  # is inherently local, so run it over SSH when --host names a remote box.
+  if [[ "$HOST" != "localhost" && "$HOST" != "127.0.0.1" ]]; then
+    echo "=== Downloading $HF_REPO ($INCLUDE) -> $HOST:$LOCAL_DIR ==="
+    ssh "$HOST" "hf download '$HF_REPO' --include '$INCLUDE' --local-dir '$LOCAL_DIR'"
+  else
+    echo "=== Downloading $HF_REPO ($INCLUDE) -> $LOCAL_DIR (local) ==="
+    hf download "$HF_REPO" --include "$INCLUDE" --local-dir "$LOCAL_DIR"
+  fi
   echo ""
   echo "Downloaded. To serve it:"
   echo "  1. add a section to presets/router.ini with model = $LOCAL_DIR/<file>.gguf"

--- a/scripts/sync-discord-alert-secret.sh
+++ b/scripts/sync-discord-alert-secret.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Syncs the Discord webhook from OpenBao into the Secret consumed by
+# AlertmanagerConfig. The webhook is never printed or written to the repo.
+set -euo pipefail
+
+: "${VAULT_ADDR:=http://100.70.90.12:8200}"
+KEYS_FILE="${OPENBAO_KEYS_FILE:-$HOME/.foundry/openbao-keys/test/keys.json}"
+VAULT_PATH="${DISCORD_VAULT_PATH:-foundry-core/monitoring/discord}"
+NAMESPACE="${MONITORING_NAMESPACE:-monitoring}"
+SECRET_NAME="${DISCORD_SECRET_NAME:-alertmanager-discord}"
+
+for binary in vault jq kubectl; do
+  command -v "$binary" >/dev/null || { echo "ERROR: $binary is required" >&2; exit 1; }
+done
+[ -r "$KEYS_FILE" ] || { echo "ERROR: cannot read $KEYS_FILE" >&2; exit 1; }
+
+export VAULT_ADDR
+export VAULT_TOKEN="$(jq -er '.root_token' "$KEYS_FILE")"
+WEBHOOK_URL="$(vault kv get -field=webhook_url "$VAULT_PATH")"
+[ -n "$WEBHOOK_URL" ] || { echo "ERROR: webhook_url is empty at $VAULT_PATH" >&2; exit 1; }
+
+kubectl -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
+  --from-literal=webhook-url="$WEBHOOK_URL" \
+  --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+echo "Synced $NAMESPACE/$SECRET_NAME from OpenBao path $VAULT_PATH"

--- a/scripts/verify-observability.sh
+++ b/scripts/verify-observability.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROM_PROXY='/api/v1/namespaces/monitoring/services/http:kube-prometheus-stack-prometheus:9090/proxy'
+
+# Jobs where EVERY target must be up.
+EXPECTED=(openbao kei-abac kei-oidc kei-web postgres-exporter-kei postgres-exporter-chatbot redis-exporter)
+
+# Jobs where AT LEAST ONE target must be up.
+#
+# llama-cpp: pedrogpt runs a llama.cpp router with --models-max 1, so only one model
+# is resident at a time and scrapes pass autoload=false (so Prometheus cannot force-load
+# ~18 GB just to collect metrics). The idle model's target returns HTTP 400 and reads
+# down as NORMAL steady state. Requiring all-up here would fail by design after every
+# model switch; requiring at-least-one-up still catches a dead router.
+EXPECTED_ANY=(llama-cpp)
+
+TARGETS="$(kubectl get --raw "$PROM_PROXY/api/v1/targets")"
+failed=0
+
+for job in "${EXPECTED[@]}"; do
+  health="$(jq -r --arg job "$job" '[.data.activeTargets[] | select(.labels.job == $job) | .health] | if length == 0 then "missing" elif all(. == "up") then "up" else join(",") end' <<<"$TARGETS")"
+  printf '%-28s %s\n' "$job" "$health"
+  [ "$health" = up ] || failed=1
+done
+
+for job in "${EXPECTED_ANY[@]}"; do
+  summary="$(jq -r --arg job "$job" '
+    [.data.activeTargets[] | select(.labels.job == $job)] as $t
+    | if ($t | length) == 0 then "missing"
+      else ([$t[] | select(.health == "up")] | length | tostring) + "/" + ($t | length | tostring) + " up"
+      end' <<<"$TARGETS")"
+  printf '%-28s %s\n' "$job" "$summary"
+  case "$summary" in
+    missing|0/*) failed=1 ;;
+  esac
+done
+
+for resource in \
+  configmap/pedro-observability-dashboards \
+  prometheusrule.monitoring.coreos.com/pedro-observability \
+  alertmanagerconfig.monitoring.coreos.com/discord; do
+  kubectl -n monitoring get "$resource" >/dev/null || failed=1
+done
+
+exit "$failed"


### PR DESCRIPTION
Moves pedrogpt from a single-model `llama-server` to llama.cpp's built-in **router mode**: the server starts with no `-m`/`--model`, and each model in `presets/router.ini` is spawned as its own child process on demand.

## Models

| API id | Model | MTP | ctx | Loads on startup |
|---|---|---|---|---|
| `qwen3.6-27b-mtp` | Qwen3.6-27B-MTP | yes (baked-in head) | 216064 | yes |
| `qwen3.8-27b` | Qwen3.8-27B (unsloth `UD-Q4_K_XL`) | no | 262144 | on demand |

`qwen3.6-27b-mtp` is preserved as the section name, so **OpenWebUI, `benchmark/`, SuperAgentPedro, iam_pedro and pedro-bots need no changes** — OpenWebUI discovers models via `/v1/models` and will simply show both.

## Why they swap instead of coexisting

Measured on the box: `qwen3.6-27b-mtp` alone uses **27.9 GB of 32.6 GB**. Two 27B Q4 models are **35.5 GB of weights before any KV cache**, so they cannot co-reside at *any* context size. `--models-max 1` makes them swap.

The upside: since each model gets the whole card, **neither had to give up context**. `qwen3.8-27b` runs at its full native **262144** window — affordable because only 16 of its 64 layers use full attention (the rest are `linear_attention` with no growing KV cache), so with `q8_0` K/V the cache is ~8.6 GB against a ~15 GB budget.

The cost: a model switch unloads ~18 GB and loads another, so the first request after switching stalls. Steady-state throughput is unaffected.

## Per-model flags stay per-model

Router children are separate processes, so `parallel = 1` (required by MTP) on one model does not constrain the other. This corrects a claim in the old `presets/README.md` that MTP "cannot run in router mode" — that conflated `parallel > 1` with router mode itself.

- `--spec-type draft-mtp` and `--mlock` live **only** in the MTP section. Inheriting `spec-type` would crash the non-MTP model on load.
- Shared flags (`--jinja`, `--metrics`, `--no-webui`, `--flash-attn`) moved to `[*]`, so **both models keep tool-call support**.
- `presets/README.md` documents the full old-flag → new-location mapping.

## Gotchas found while building this

- **`router.ini` deliberately omits the `version = 1` line** the other INIs carry. Keys above the first section header register a phantom model named `default` that appears in `/v1/models` and fails when selected. Verified on build b9802; upstream's own `docs/preset.md` omits it too.
- **`/metrics` now requires `?model=<id>`** or returns HTTP 400 — it is proxied to the child. Both ScrapeConfigs pass it, plus `autoload=false` so a 15s scrape of the *idle* model cannot force-load ~18 GB and permanently thrash the GPU. Expect one of the two llama jobs to be down at any time; that is correct. `/health` is unaffected.
- **`setup-llama-cpp.sh` wrote an env file whose variables `run-server.sh` no longer reads** — a fresh install would have produced a broken server. Updated.
- `switch-model.sh` rewritten over the router load/unload API; its old premise (rewrite `MODEL=`, restart) no longer exists.
- Retired preset INIs marked `DEPRECATED` rather than deleted.
- `helm/observability` generates one llama-cpp ScrapeConfig per entry in `.Values.pedrogpt.models`.

## Verification

Deployed and verified on pedrogpt (build b9802):

- Router process running with no `-m`; MTP child spawned with `--spec-type draft-mtp`, draft caches, `--mlock`, ctx 216064
- Both models registered, **no phantom `default` entry**
- `/health` → 200; `/metrics` → 400 without `?model=`, 33 metrics with it
- Completions correct on both models; swap/evict working in both directions
- `qwen3.8-27b` confirmed live at ctx **262144**

## Follow-ups (not in this PR)

- **ScrapeConfigs are not yet applied to the cluster** — Prometheus is still scraping bare `/metrics`, so llama metrics are currently down in Grafana.
- `scripts/verify-observability.sh` (untracked) asserts all `llama-cpp` targets are `up`; that check needs relaxing for the idle model.
- `qwen3.6-27b-mtp` is trained to 262144 but runs at 216064. Raising it is plausible but unverified — extrapolation puts it at ~30.1 GB of 32.6 GB, only ~2.5 GB headroom. Procedure documented in `presets/README.md`.
- `qwen3.8-27b` reasons by default (no `enable_thinking:false`). `reasoning = off` is a valid preset key if that is unwanted.

Client-side counterpart: Soypete/dotfiles#28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3GEemb58wn1mgXynnbzMt